### PR TITLE
format codes and fix warnings

### DIFF
--- a/about.h
+++ b/about.h
@@ -1,52 +1,52 @@
 #ifndef _ABOUT_H_
-#define _ABOUT_H_                                                                                                                          
-                                                                                                                          
-#define LINE1 "             ffffffffffffffff                                                   "     
-#define LINE2 "           f::::::::::::::::f                                                   "               
-#define LINE3 "          f::::::::::::::::::f                                                  "                
-#define LINE4 "          f::::::fffffff:::::f                                                  "                
-#define LINE5 "          f:::::f       ffffffwwwwwww           wwwww           wwwwwww         "                   
-#define LINE6 "          f:::::f              w:::::w         w:::::w         w:::::w          "                    
-#define LINE7 "         f:::::::ffffff         w:::::w       w:::::::w       w:::::w           "                     
+#define _ABOUT_H_
+
+#define LINE1 "             ffffffffffffffff                                                   "
+#define LINE2 "           f::::::::::::::::f                                                   "
+#define LINE3 "          f::::::::::::::::::f                                                  "
+#define LINE4 "          f::::::fffffff:::::f                                                  "
+#define LINE5 "          f:::::f       ffffffwwwwwww           wwwww           wwwwwww         "
+#define LINE6 "          f:::::f              w:::::w         w:::::w         w:::::w          "
+#define LINE7 "         f:::::::ffffff         w:::::w       w:::::::w       w:::::w           "
 #define LINE8 " ------- f::::::::::::f          w:::::w     w:::::::::w     w:::::w -------    "
 #define LINE9 " -:::::- f::::::::::::f           w:::::w   w:::::w:::::w   w:::::w  -:::::-    "
 #define LINE10 " ------- f:::::::ffffff            w:::::w w:::::w w:::::w w:::::w   -------   "
 #define LINE11 "         f:::::f                   w:::::w:::::w   w:::::w:::::w               "
 #define LINE12 "         f:::::f                    w:::::::::w     w:::::::::w                "
 #define LINE13 "         f:::::::f                    w:::::::w       w:::::::w                "
-#define LINE14 "         f:::::::f                     w:::::w         w:::::w                 " 
-#define LINE15 "         f:::::::f                      w:::w           w:::w                  "    
-#define LINE16 "         fffffffff                       www             www                   "     
-       
+#define LINE14 "         f:::::::f                     w:::::w         w:::::w                 "
+#define LINE15 "         f:::::::f                      w:::w           w:::w                  "
+#define LINE16 "         fffffffff                       www             www                   "
 
-#define ALINE1 "          _____          \n"     
+
+#define ALINE1 "          _____          \n"
 #define ALINE2 "        _/ ____|_  _  __ \n"
 #define ALINE3 "        |   __|| |/ |/ / \n"
 #define ALINE4 "         |__|   |____/ \nFile vieWer - Coded by v3l0r3k\n\0"
 
 #define ABOUT_LENGTH 100
 #define ABOUT_LINES 16
-                                                                                                          
 
-char about_msg[ABOUT_LINES][ABOUT_LENGTH] =                                                                                                       
+
+char about_msg[ABOUT_LINES][ABOUT_LENGTH] =
                {
-		 LINE1,
-		 LINE2,
-		 LINE3,
-		 LINE4,
-		 LINE5,
-		 LINE6,
-		 LINE7,
-		 LINE8,
-		 LINE9,
-		 LINE10,
-		 LINE11,
-		 LINE12,
-		 LINE13,
-		 LINE14,
-		 LINE15,
-		 LINE16
- 		};                                                                                                                                                                    
-                                                                                                                                                                                               
-                                                                                                          
+         LINE1,
+         LINE2,
+         LINE3,
+         LINE4,
+         LINE5,
+         LINE6,
+         LINE7,
+         LINE8,
+         LINE9,
+         LINE10,
+         LINE11,
+         LINE12,
+         LINE13,
+         LINE14,
+         LINE15,
+         LINE16
+        };
+
+
 #endif

--- a/fileb.c
+++ b/fileb.c
@@ -1,11 +1,11 @@
-/* 
+/*
 ======================================================================
 Module to describe basic file operations.
 
 @author : Velorek
 @version : 1.0
- 
-LAST MODIFIED : 14/04/2019 - Rename headers 
+
+LAST MODIFIED : 14/04/2019 - Rename headers
 ======================================================================
 */
 
@@ -26,7 +26,7 @@ LAST MODIFIED : 14/04/2019 - Rename headers
 int file_exists(char *fileName) {
   int     ok;
   if(access(fileName, F_OK) != -1) {
-    ok = 1;			//File exists
+    ok = 1;         //File exists
   } else {
     ok = 0;
   }
@@ -56,12 +56,12 @@ long countLinesFile(FILE * filePtr) {
   char    ch;
   long    counterA = 0;
   if(filePtr != NULL) {
-    rewind(filePtr);		//Make sure we are at the beginning
+    rewind(filePtr);        //Make sure we are at the beginning
 
-    ch = getc(filePtr);		//Peek ahead in the file
+    ch = getc(filePtr);     //Peek ahead in the file
     while(!feof(filePtr)) {
       if(ch == 10) {
-	counterA++;
+    counterA++;
       }
       ch = getc(filePtr);
     }
@@ -73,12 +73,12 @@ long gotoLine(FILE * filePtr, long line) {
   long    counterA = 0;
   long   result=0;
   if(filePtr != NULL) {
-    rewind(filePtr);		//Make sure we are at the beginning
+    rewind(filePtr);        //Make sure we are at the beginning
 
-    ch = getc(filePtr);		//Peek ahead in the file
+    ch = getc(filePtr);     //Peek ahead in the file
     while(!feof(filePtr)) {
       if(ch == 10) {
-	counterA++;
+    counterA++;
       }
       if (line == counterA) break;
       ch = getc(filePtr);
@@ -99,14 +99,14 @@ long checkFile(FILE * filePtr) {
   char    ch;
   long    counterA = 0;
   if(filePtr != NULL) {
-    rewind(filePtr);		//Make sure we are at the beginning
+    rewind(filePtr);        //Make sure we are at the beginning
 
-    ch = getc(filePtr);		//Peek ahead in the file
+    ch = getc(filePtr);     //Peek ahead in the file
     while(!feof(filePtr)) {
       if(ch < 9) {
-	//discard accents
-	if(ch > -60)
-	  counterA++;
+    //discard accents
+    if(ch > -60)
+      counterA++;
       }
       ch = getc(filePtr);
     }
@@ -120,9 +120,9 @@ long checkFile(FILE * filePtr) {
 /*-----------*/
 
 int openFile(FILE ** filePtr, char fileName[], char *mode)
-/* 
+/*
 Open file.
-@return ok = 1 ? 0 Success! 
+@return ok = 1 ? 0 Success!
 */
 {
   int     ok = 0;
@@ -143,9 +143,9 @@ Open file.
 /*------------*/
 
 int closeFile(FILE * filePtr) {
-/* 
+/*
    Close file
-@return ok: 
+@return ok:
 */
   int     ok=0;
 

--- a/fileb.h
+++ b/fileb.h
@@ -1,10 +1,10 @@
 /*
 ========================================================================
-- HEADER - 
+- HEADER -
 Module to handle basic file operations
 @author : Velorek
-@version : 1.0  
-Last modified: 14/04/2019 Rename headers                                                              
+@version : 1.0
+Last modified: 14/04/2019 Rename headers
 ========================================================================
 */
 

--- a/keyb.c
+++ b/keyb.c
@@ -1,10 +1,10 @@
-/* 
+/*
 ======================================================================
 Module to control keyboard input.
 
 @author : Velorek
 @version : 1.0
- 
+
 LAST MODIFIED : 14/04/2019 Rename headers
 ======================================================================
 */
@@ -26,12 +26,12 @@ LAST MODIFIED : 14/04/2019 Rename headers
 /*----------------------------------*/
 
 int read_keytrail(char chartrail[5]){
-/* 
+/*
    New implementation: Trail of chars found in keyboard.c
    If K_ESCAPE is captured read a trail up to 5 characters from the console.
    This is to control the fact that some keys may change
    according to the terminal and expand the editor's possibilities.
-   Eg: F2 can be either 27 79 81 or 27 91 91 82.  
+   Eg: F2 can be either 27 79 81 or 27 91 91 82.
 */
 char ch;
 int i;
@@ -44,7 +44,7 @@ int i;
         chartrail[i] = 0;
      }
    }
-   resetch();		    
+   resetch();
    return 1;
 }
 
@@ -55,7 +55,7 @@ int i;
 
 int read_accent(char *ch, char accentchar[2])
 {
-/* 
+/*
 Input Ref: ch, accentchar
 @return : 1 - SET 1 | 2 - SET 2 | 0 - NO ACCENT CHAR
 */
@@ -65,13 +65,13 @@ Input Ref: ch, accentchar
    accentchar[0] = 0;
    accentchar[1] = *ch;
     if(*ch == SPECIAL_CHARS_SET1) {
-      accentchar[0] = SPECIAL_CHARS_SET1;	//Accents and special chars SET1
+      accentchar[0] = SPECIAL_CHARS_SET1;   //Accents and special chars SET1
       accentchar[1] = readch();
       result = 1;
       resetch();
     }
     if(*ch == SPECIAL_CHARS_SET2) {
-      accentchar[0] = SPECIAL_CHARS_SET2;	//Accents and special chars SET2
+      accentchar[0] = SPECIAL_CHARS_SET2;   //Accents and special chars SET2
       accentchar[1] = readch();
       result = 2;
       resetch();

--- a/keyb.h
+++ b/keyb.h
@@ -1,11 +1,11 @@
 /*
 ========================================================================
-- HEADER - 
+- HEADER -
 Module to handle keyboard input in Linux and create
 a further layer of abstraction.
 @author : Velorek
-@version : 1.0  
-Last modified: 14/04/2019 Rename Headers                                                                
+@version : 1.0
+Last modified: 14/04/2019 Rename Headers
 ========================================================================
 */
 

--- a/listc.c
+++ b/listc.c
@@ -1,12 +1,12 @@
-/* 
+/*
 ======================================================================
 Module to make a circular linked list to make a selection menu in C.
 
 @author : Velorek
 @version : 1.0
 Last modified : 11/02/2019 - Switch to readch() instead of readch()
-                06/04/2019 - Fixed memory errors and leaks. 
-		14/04/2019 - Rename headers
+                06/04/2019 - Fixed memory errors and leaks.
+        14/04/2019 - Rename headers
 ======================================================================
 */
 
@@ -25,8 +25,8 @@ Last modified : 11/02/2019 - Switch to readch() instead of readch()
 /*====================================================================*/
 
 //DROP-DOWN MENU VALUES
-#define K_LEFTMENU -1		//Left arrow key pressed while in menu
-#define K_RIGHTMENU -2		//Right arrow key pressed while in menu
+#define K_LEFTMENU -1       //Left arrow key pressed while in menu
+#define K_RIGHTMENU -2      //Right arrow key pressed while in menu
 #define ESC_KEY 1
 #define EXIT_FLAG 1
 
@@ -41,16 +41,16 @@ Last modified : 11/02/2019 - Switch to readch() instead of readch()
 /*====================================================================*/
 
 typedef struct _listchoice {
-  int     index;		// Item number
-  int     backcolor0;		// Back and Fore colors when not selected
+  int     index;        // Item number
+  int     backcolor0;       // Back and Fore colors when not selected
   int     forecolor0;
-  int     backcolor1;		// Back and Fore colors when selected
+  int     backcolor1;       // Back and Fore colors when selected
   int     forecolor1;
-  int     wherex;		// Position of the item
+  int     wherex;       // Position of the item
   int     wherey;
-  char   *item;			// Item string
-  struct _listchoice *next;	// Pointer to next item
-  struct _listchoice *back;	// Pointer to previous item.
+  char   *item;         // Item string
+  struct _listchoice *next; // Pointer to next item
+  struct _listchoice *back; // Pointer to previous item.
 } LISTCHOICE;
 
 /*====================================================================*/
@@ -71,7 +71,7 @@ LISTCHOICE *current = NULL;
 /*------------*/
 
 void add_item(LISTCHOICE * list_identifier, char *str, int x, int y,
-	      int bcolor0, int fcolor0, int bcolor1, int fcolor1) {
+          int bcolor0, int fcolor0, int bcolor1, int fcolor1) {
   LISTCHOICE *newp;
   if(head == NULL && list_identifier == NULL) {
     //Reserve memory
@@ -93,13 +93,13 @@ void add_item(LISTCHOICE * list_identifier, char *str, int x, int y,
     list_identifier->index = 0;
   } else {
     //Circular list structure
-    former = tail;		//pointer to previous item
+    former = tail;      //pointer to previous item
     newp = (LISTCHOICE *) malloc(sizeof(LISTCHOICE));
-    former->next = newp;	//previous item points to current item
-    newp->back = former;	//new item back points to previous item
-    tail = newp;		//tail always points to the last item
-    head->back = tail;		// This way we close the circular list : First item back points to last item
-    tail->next = head;		//Last item next points to first item
+    former->next = newp;    //previous item points to current item
+    newp->back = former;    //new item back points to previous item
+    tail = newp;        //tail always points to the last item
+    head->back = tail;      // This way we close the circular list : First item back points to last item
+    tail->next = head;      //Last item next points to first item
 
     //Create first item of the list and assign properties to it.
     newp->backcolor0 = bcolor0;
@@ -119,38 +119,38 @@ void add_item(LISTCHOICE * list_identifier, char *str, int x, int y,
 /*Remove list from memory*/
 /*-----------------------*/
 /* Function to delete the entire linked list */
-void free_list(LISTCHOICE *list_identifier) 
-{ 
+void free_list(LISTCHOICE *list_identifier)
+{
    /* deref head_ref to get the real head */
-   LISTCHOICE *cur; 
-   LISTCHOICE *back; 
+   LISTCHOICE *cur;
+   LISTCHOICE *back;
    cur = tail;
-   while (cur != head)  
-   { 
-       back = cur->back; 
+   while (cur != head)
+   {
+       back = cur->back;
        //if (current != NULL){
          free(cur->item);
          free(cur);
        //}
-       cur = back; 
-   } 
+       cur = back;
+   }
    free(head->item);
-   free(head);  
-   /* deref head_ref to affect the real head back 
+   free(head);
+   /* deref head_ref to affect the real head back
       in the caller. */
-   head = NULL; 
+   head = NULL;
    tail = NULL;
    *list_identifier = *list_identifier; //to silence warning
-} 
+}
 /*
 void free_list(LISTCHOICE * list_identifier) {
   LISTCHOICE *aux, *p;
   aux = tail;
   while (aux != head->back) {
     p = aux;
-    if (p->item != NULL) free(p->item);		//free off the string field
-    if (p != NULL) free(p);			//remove item
-  } 
+    if (p->item != NULL) free(p->item);     //free off the string field
+    if (p != NULL) free(p);         //remove item
+  }
   head = NULL;
   tail = NULL;
   former = NULL;
@@ -159,24 +159,24 @@ void free_list(LISTCHOICE * list_identifier) {
 */
 
 /*-----------------------------------------*/
-/* Displays the items contained in the list 
+/* Displays the items contained in the list
    with the properties specified.          */
 /*-----------------------------------------*/
 
 void display_list(LISTCHOICE * list_identifier) {
-/* 
+/*
 Displays the items contained in the list with the properties specified
 in init_list.
 until the auxiliary pointer reaches the first item again
 First item is equal to tail->next.
 */
- 
+
   LISTCHOICE *aux;
   aux = head;
-  *list_identifier = *list_identifier; //to silence warning/new implementation needed  
+  *list_identifier = *list_identifier; //to silence warning/new implementation needed
   do {
     write_str(aux->wherex, aux->wherey, aux->item, aux->backcolor0,
-	      aux->forecolor0);
+          aux->forecolor0);
     aux = aux->next;
   } while(aux != tail->next);
   update_screen();
@@ -190,24 +190,24 @@ First item is equal to tail->next.
 void move_selector(LISTCHOICE * aux, short direction) {
   //Unmark previous iten
   write_str(aux->wherex, aux->wherey, aux->item, aux->backcolor0,
-	    aux->forecolor0);
+        aux->forecolor0);
   //Highlight current item
   switch (direction) {
     case DIR_UP:
       *aux = *aux->back;
-      break;			//Go to next item
+      break;            //Go to next item
     case DIR_DOWN:
       *aux = *aux->next;
-      break;			//Go to next item
+      break;            //Go to next item
     case DIR_LEFT:
       *aux = *aux->next;
-      break;			//Go to next item
+      break;            //Go to next item
     case DIR_RIGHT:
       *aux = *aux->back;
-      break;			//Go to next item
+      break;            //Go to next item
   }
   write_str(aux->wherex, aux->wherey, aux->item, aux->backcolor1,
-	    aux->forecolor1);
+        aux->forecolor1);
   update_screen();
 }
 
@@ -222,42 +222,42 @@ char start_vmenu(LISTCHOICE * list_data) {
   int     esc_key = 0;
   char chartrail[5];
   unsigned keypressed = 0;
-  display_list(list_data);	//display whole list
+  display_list(list_data);  //display whole list
 
   //Highlight first item on the list
-  aux = *tail;			//Auxiliary variable points to last item
-  move_selector(&aux, DIR_DOWN);	//Move down to point to highlight first item.
+  aux = *tail;          //Auxiliary variable points to last item
+  move_selector(&aux, DIR_DOWN);    //Move down to point to highlight first item.
 
-  ch = 0;			//init ch value
-  while(ch != K_ENTER)		// escape key or enter
+  ch = 0;           //init ch value
+  while(ch != K_ENTER)      // escape key or enter
   {
    keypressed = kbhit();
    if (keypressed == 1){
       ch = readch();
       keypressed = 0;
-    
-      if(ch == K_ESCAPE)		// escape key
+
+      if(ch == K_ESCAPE)        // escape key
       {
-        read_keytrail(chartrail);	// read key again for arrow key combinations
+        read_keytrail(chartrail);   // read key again for arrow key combinations
         esc_key = ESC_KEY;
         if(strcmp(chartrail, K_UP_TRAIL) == 0) {
-	  move_selector(&aux, DIR_UP);
-	  esc_key = 0;
-	}
-	if(strcmp(chartrail, K_DOWN_TRAIL) == 0) {
-	  move_selector(&aux, DIR_DOWN);
-	  esc_key = 0;
-	}
+      move_selector(&aux, DIR_UP);
+      esc_key = 0;
+    }
+    if(strcmp(chartrail, K_DOWN_TRAIL) == 0) {
+      move_selector(&aux, DIR_DOWN);
+      esc_key = 0;
+    }
         if(strcmp(chartrail, K_RIGHT_TRAIL) == 0) {
-	  ch = K_LEFTMENU;	// this will be used in top-down menu. Mark for left arrow key
-	  exitwhile = EXIT_FLAG;
-	  esc_key = 0;
-	}
+      ch = K_LEFTMENU;  // this will be used in top-down menu. Mark for left arrow key
+      exitwhile = EXIT_FLAG;
+      esc_key = 0;
+    }
         if(strcmp(chartrail, K_LEFT_TRAIL) == 0) {
-	  ch = K_RIGHTMENU;	// this will be used in top-down menu. Mark for right arrow key
-	  exitwhile = EXIT_FLAG;
-	  esc_key = 0;
-	}
+      ch = K_RIGHTMENU; // this will be used in top-down menu. Mark for right arrow key
+      exitwhile = EXIT_FLAG;
+      esc_key = 0;
+    }
       }
     }
     if(esc_key == ESC_KEY) {
@@ -272,7 +272,7 @@ char start_vmenu(LISTCHOICE * list_data) {
     *list_data = aux;
     resetch();
   }
-  return ch;			// return the key or code pressed
+  return ch;            // return the key or code pressed
 
 }
 
@@ -286,40 +286,40 @@ char start_hmenu(LISTCHOICE * list_data) {
   char chartrail[5];
   LISTCHOICE aux;
 
-  display_list(list_data);	//display whole list
+  display_list(list_data);  //display whole list
 
   //Highlight first item on the list
-  aux = *tail;			//Auxiliary variable points to last item
-  move_selector(&aux, DIR_LEFT);	//Move down to point to highlight first item.
+  aux = *tail;          //Auxiliary variable points to last item
+  move_selector(&aux, DIR_LEFT);    //Move down to point to highlight first item.
 
-  ch = 0;			//init ch value
-  while(ch != K_ENTER)		// escape key or enter
+  ch = 0;           //init ch value
+  while(ch != K_ENTER)      // escape key or enter
   {
      keypressed = kbhit();
      if (keypressed == 1){
       ch = readch();
       keypressed = 0;
-    
-      if(ch == K_ESCAPE)		// escape key
+
+      if(ch == K_ESCAPE)        // escape key
       {
-        read_keytrail(chartrail);	// read key again for arrow key combinations
+        read_keytrail(chartrail);   // read key again for arrow key combinations
         //esc_key = ESC_KEY;
         if(strcmp(chartrail, K_RIGHT_TRAIL) == 0) {
-	  move_selector(&aux, DIR_LEFT);
-	  //esc_key = 0;
-	}
+      move_selector(&aux, DIR_LEFT);
+      //esc_key = 0;
+    }
         if(strcmp(chartrail, K_LEFT_TRAIL) == 0) {
-	  move_selector(&aux, DIR_RIGHT);
-	  //esc_key = 0;
-	}
-  
+      move_selector(&aux, DIR_RIGHT);
+      //esc_key = 0;
+    }
+
 //    if(exitloop == EXIT_FLAG)
   //    break;
-//	default:
-//	  exitloop = EXIT_FLAG;
-//	  break;
+//  default:
+//    exitloop = EXIT_FLAG;
+//    break;
       }
-    
+
        if (ch == K_TAB) move_selector(&aux, DIR_LEFT);
     }
   }

--- a/listc.h
+++ b/listc.h
@@ -1,8 +1,8 @@
-/* 
+/*
 ======================================================================
 HEADER:
 Module to create vertical and horizontal selection menus with
-double linked list. 
+double linked list.
 @author : Velorek
 @version : 1.0
 -LAST MODIFIED : 14/04/2019 Rename headers
@@ -27,16 +27,16 @@ double linked list.
 /*====================================================================*/
 
 typedef struct _listchoice {
-  int     index;		// Item number
-  int     backcolor0;		// Back and Fore colors when not selected
+  int     index;        // Item number
+  int     backcolor0;       // Back and Fore colors when not selected
   int     forecolor0;
-  int     backcolor1;		// Back and Fore colors when selected
+  int     backcolor1;       // Back and Fore colors when selected
   int     forecolor1;
-  int     wherex;		// Position of the item
+  int     wherex;       // Position of the item
   int     wherey;
-  char   *item;			// Item string
-  struct _listchoice *next;	// Pointer to next item
-  struct _listchoice *back;	// Pointer to previous item.
+  char   *item;         // Item string
+  struct _listchoice *next; // Pointer to next item
+  struct _listchoice *back; // Pointer to previous item.
 } LISTCHOICE;
 
 /*====================================================================*/
@@ -44,7 +44,7 @@ typedef struct _listchoice {
 /*====================================================================*/
 
 void    add_item(LISTCHOICE * list_identifier, char *str, int x, int y,
-		 int bcolor0, int fcolor0, int bcolor1, int fcolor1);
+         int bcolor0, int fcolor0, int bcolor1, int fcolor1);
 void    free_list(LISTCHOICE * list_identifier);
 void    display_list(LISTCHOICE * list_identifier);
 char    start_vmenu(LISTCHOICE * list_data);

--- a/main.c
+++ b/main.c
@@ -22,25 +22,25 @@ Last modified : 03/01/2021 - Horizontal scroll added
 #define HORIZONTAL_SHIFT 500 //maximum horizontal scroll
 
 //FUNCTION PROTOTYPES
-void main_screen();
+void main_screen(void);
 void cleanArea(int raw);
-void tick2();
+void tick2(void);
 void tick1(int *num, int *i);
-int refresh_screen();
+int refresh_screen(void);
 int special_keys(char ch);
 int handleopenFile(FILE ** filePtr, char *fwfileName);
-void credits();
+void credits(void);
 void filetoDisplay(FILE *filePtr, int scupdate);
 void scroll(FILE *filePtr);
 char* check_arguments(int argc, char *argv[]);
-long checkScrollValues();
+long checkScrollValues(void);
 void    drop_down(char *kglobal);
-char horizontal_menu();
-int fileInfoDialog();
-void about_info();
-char *setfile();
-int help_info();
-void update_indicators();
+char horizontal_menu(void);
+int fileInfoDialog(void);
+void about_info(void);
+char *setfile(void);
+int help_info(void);
+void update_indicators(void);
 
 /* -----------------------------------*/
 //GLOBAL VARIABLES
@@ -48,7 +48,7 @@ int scW, scH, old_scW, old_scH; //screen dimensions
 char currentPath[MAX_TEXT1];
 char fwfileName[MAX_TEXT2];
 char msg[TITLE_LENGTH] = "=-[fw]:FILE VIEWER v0.1-=\0";
-char    kglobal = 0;		// Global variable for menu animation
+char    kglobal = 0;        // Global variable for menu animation
 LISTCHOICE *mylist, data; //menus handler
 SCROLLDATA openFileData; //openFile dialog
 LISTCHOICE *mylist, data; //menus handler
@@ -90,10 +90,10 @@ int keypressed=0;
   mytimer3.ms = 100;
   mytimer3.ticks = 0; // Timer 3 - Screen display control
   pushTerm();  //record previous terminal settings
-  create_screen(); 
+  create_screen();
   get_terminal_dimensions(&scH, &scW);
   if (scW >79 && scH > 23) displayLogo = 1;
-  else displayLogo = 0; 
+  else displayLogo = 0;
   displayLength = scH - 5;
   old_scH = scH;
   old_scW = scW;
@@ -105,26 +105,26 @@ int keypressed=0;
   check_arguments(argc, argv);
   /*------------------------MAIN PROGRAM LOOP---------------------------*/
   do{
-	//TIMER 1
-      if (timerC(&mytimer1) == 1) { 
- 	 //Title animation
-	 tick1(&num, &i);
+    //TIMER 1
+      if (timerC(&mytimer1) == 1) {
+     //Title animation
+     tick1(&num, &i);
        }
-	//TIMER 2
-      if (timerC(&mytimer2) == 1) { 
-	 //Time animation
+    //TIMER 2
+      if (timerC(&mytimer2) == 1) {
+     //Time animation
          tick2();
-       } 
-	//TIMER 3
+       }
+    //TIMER 3
        if (timerC(&mytimer3) == 1) {
         //Update screen control and screen refresh
          //if(time_since_keypressed > 5) time_since_keypressed = 0;
-	 if (keypressed == 0) time_since_keypressed++;
-	else
-	  time_since_keypressed = 0;
+     if (keypressed == 0) time_since_keypressed++;
+    else
+      time_since_keypressed = 0;
          //check screen dimensions & update if changed
          refresh_screen(0);
-       } 
+       }
    //CHECK KEYS
    keypressed = kbhit();
    if (keypressed == 1){
@@ -137,43 +137,43 @@ int keypressed=0;
    if (filePtr != NULL){
       if (ch =='a') {
         //Left-arrow key
-         if(currentColumn > 0) {currentColumn--; cleanArea(1); scroll(filePtr);}  
-      } 
+         if(currentColumn > 0) {currentColumn--; cleanArea(1); scroll(filePtr);}
+      }
       if (ch =='d') {
         //Right-arrow key
-         if(currentColumn < HORIZONTAL_SHIFT) {currentColumn++; cleanArea(1); scroll(filePtr);}  
+         if(currentColumn < HORIZONTAL_SHIFT) {currentColumn++; cleanArea(1); scroll(filePtr);}
       }
       if (ch =='w') {
         //Up-arrow key
          if(currentLine >0) {currentLine--; if (currentColumn > 1) cleanArea(1);scroll(filePtr);}
-      } 
+      }
       if (ch == 's') {
-        //Down-arrow key 
- 	  if (scrollActive == 1){
-	     if (currentLine<scrollLimit) currentLine++; 
-	     if (currentColumn > 1) cleanArea(1);
-	     scroll(filePtr);
-   	  }
+        //Down-arrow key
+      if (scrollActive == 1){
+         if (currentLine<scrollLimit) currentLine++;
+         if (currentColumn > 1) cleanArea(1);
+         scroll(filePtr);
+      }
        }
     }
     if (ch == K_CTRL_C) status = -1;
     if (ch == K_CTRL_L) {
-	filetoDisplay(filePtr,  1);
+    filetoDisplay(filePtr,  1);
        if(horizontal_menu() == K_ESCAPE) {
- 	//Exit horizontal menu with ESC 3x
-	kglobal = K_ESCAPE;
-	main_screen();
+    //Exit horizontal menu with ESC 3x
+    kglobal = K_ESCAPE;
+    main_screen();
        }
        drop_down(&kglobal);
      }
      } else{
-     
+
      if (filePtr != NULL && update == 1 && time_since_keypressed>1) {
-	//Screen buffer is updated here! Screenshot of what is shown on screen
-	filetoDisplay(filePtr, 1); 
-	update = 0;
-	time_since_keypressed = 0;
-     } 
+    //Screen buffer is updated here! Screenshot of what is shown on screen
+    filetoDisplay(filePtr, 1);
+    update = 0;
+    time_since_keypressed = 0;
+     }
      ch = 0;
      keypressed = 0;
    }
@@ -188,7 +188,7 @@ int keypressed=0;
 //DISPLAY
 /* --------------------------------------*/
 
-void main_screen(){
+void main_screen(void){
 int i=0;
    screen_color(BH_BLUE);
   for (i=1;i<scW; i++){
@@ -213,7 +213,7 @@ int i=0;
   update_indicators();
   if (displayLogo == 1){
   for (i=0; i<ABOUT_LINES; i++)
-	write_str((scW/2) - (80/2), ((scH/2) - (ABOUT_LINES/2)) + i, about_msg[i], BH_BLUE, F_WHITE);
+    write_str((scW/2) - (80/2), ((scH/2) - (ABOUT_LINES/2)) + i, about_msg[i], BH_BLUE, F_WHITE);
   }
   update_screen();
 }
@@ -229,55 +229,55 @@ void tick1(int *num, int *i){
   } else {
     outputcolor(B_BLUE,F_WHITE);
     gotoxy(((scW/2)-TITLE_LENGTH/2)+*i+2,1);
-    printf("%c\n",msg[*i-1]); 
+    printf("%c\n",msg[*i-1]);
     *num = 0;
   }
   if (*i>TITLE_LENGTH) {
-    *i = 0; 
-    *num=0; 
+    *i = 0;
+    *num=0;
     outputcolor(B_BLUE,F_BLUE);
     gotoxy(((scW/2)-10),1);
-    printf("%s\n",msg); 
+    printf("%s\n",msg);
    }
 }
 
-void tick2(){
-//Time 
+void tick2(void){
+//Time
   time_t  mytime = time(NULL);
   char   *time_str = ctime(&mytime);
   time_str[strlen(time_str) - 1] = '\0';
   //display system time
   outputcolor(B_WHITE,F_BLACK);
   gotoxy(scW - strlen(time_str), 2);
-  printf("%s\n",time_str); 
+  printf("%s\n",time_str);
 }
 
 int refresh_screen() {
-/* Query terminal dimensions again and check if resize 
+/* Query terminal dimensions again and check if resize
    has been produced */
    get_terminal_dimensions(&scH, &scW);
     if (scW >79 && scH > 23) displayLogo = 1;
-     else displayLogo = 0; 
+     else displayLogo = 0;
      displayLength = scH - 5;
      hdisplayLength = scW;
      if (filePtr != NULL && scrollActive == 1) scrollLimit = checkScrollValues();      //Update scroll values
     if(scH != old_scH || scW != old_scW){
-        free_buffer();		//delete structure from memory for resize
-        create_screen();		//create new structure 
-        main_screen();		//Refresh screen in case of resize
+        free_buffer();      //delete structure from memory for resize
+        create_screen();        //create new structure
+        main_screen();      //Refresh screen in case of resize
         if (linesinFile > displayLength) scrollActive = 1;
         else scrollActive = 0;
         update=1;
-	update_indicators();
+    update_indicators();
         old_scH = scH;
         old_scW = scW;
-	return 1;
-    } 
+    return 1;
+    }
   return 0;
 }
 
-void update_indicators(){
-int i; 
+void update_indicators(void){
+int i;
  for (i=1;i<scW; i++){
        write_ch(i,2,' ',B_WHITE,F_WHITE);
        write_ch(i,3,' ',B_BLACK,F_BLACK);
@@ -287,11 +287,11 @@ int i;
 
   write_ch(12,2,NVER_LINE, B_WHITE,F_BLACK);
   if (strcmp(currentPath,"\0") == 0) {
-  	write_str(1,3,"No file open!",B_BLACK,F_WHITE);
+    write_str(1,3,"No file open!",B_BLACK,F_WHITE);
     } else
     {
-	write_str(14,2,fwfileName,B_WHITE,F_BLACK);
-	write_str(1,3,currentPath,B_BLACK,F_WHITE);
+    write_str(14,2,fwfileName,B_WHITE,F_BLACK);
+    write_str(1,3,currentPath,B_BLACK,F_WHITE);
    }
   write_str(1, 2, "File  Help", B_WHITE, F_BLACK);
   write_str(1, 2, "F", B_WHITE, F_BLUE);
@@ -305,19 +305,19 @@ int i;
 
 int special_keys(char ch) {
 /* MANAGE SPECIAL KEYS */
-/* 
+/*
    New implementation: Trail of chars found in keyb.c
    If K_ESCAPE is captured read a trail up to 5 characters from the console.
    This is to control the fact that some keys may change
    according to the terminal and expand the editor's possibilities.
-   Eg: F2 can be either 27 79 81 or 27 91 91 82.  
-   - Note : if (currentColumn > 1) cleanArea(1);	
-	When horizontal scroll is active all the screen is cleaned when moving.
+   Eg: F2 can be either 27 79 81 or 27 91 91 82.
+   - Note : if (currentColumn > 1) cleanArea(1);
+    When horizontal scroll is active all the screen is cleaned when moving.
 */
 
   char    chartrail[5];
   if(ch == K_ESCAPE) {
-    read_keytrail(chartrail);	//Read trail after ESC key
+    read_keytrail(chartrail);   //Read trail after ESC key
 
     //Check key trails for special keys.
 
@@ -327,57 +327,57 @@ int special_keys(char ch) {
       //update screen
       filetoDisplay(filePtr, 0);
       if(horizontal_menu() == K_ESCAPE) {
-	//Exit horizontal menu with ESC 3x
-	kglobal = K_ESCAPE;
-	main_screen();
+    //Exit horizontal menu with ESC 3x
+    kglobal = K_ESCAPE;
+    main_screen();
       }
      drop_down(&kglobal);
     } else if(strcmp(chartrail, K_F1_TRAIL) == 0 ||
-	      strcmp(chartrail, K_F1_TRAIL2) == 0) {
-      help_info(); 
+          strcmp(chartrail, K_F1_TRAIL2) == 0) {
+      help_info();
       // ARROW KEYS
     } else if((strcmp(chartrail, K_LEFT_TRAIL) == 0) && filePtr != NULL ) {
       //Left-arrow key
-       if(currentColumn > 0) {currentColumn--; cleanArea(1); scroll(filePtr);}  
+       if(currentColumn > 0) {currentColumn--; cleanArea(1); scroll(filePtr);}
     } else if((strcmp(chartrail, K_RIGHT_TRAIL) == 0)  && filePtr != NULL ) {
       //Right-arrow key
-       if(currentColumn < HORIZONTAL_SHIFT) {currentColumn++; cleanArea(1); scroll(filePtr);}  
+       if(currentColumn < HORIZONTAL_SHIFT) {currentColumn++; cleanArea(1); scroll(filePtr);}
     } else if((strcmp(chartrail, K_UP_TRAIL) == 0)  && filePtr != NULL ) {
       //Up-arrow key
        if(currentLine >0) {currentLine--; if (currentColumn > 1) cleanArea(1);scroll(filePtr);}
     } else if((strcmp(chartrail, K_DOWN_TRAIL) == 0)  && filePtr != NULL ) {
-      //Down-arrow key 
- 	if (scrollActive == 1){
-	   if (currentLine<scrollLimit) currentLine++; 
-	   if (currentColumn > 1) cleanArea(1);
-	   scroll(filePtr);
-	}
+      //Down-arrow key
+    if (scrollActive == 1){
+       if (currentLine<scrollLimit) currentLine++;
+       if (currentColumn > 1) cleanArea(1);
+       scroll(filePtr);
+    }
      } else if((strcmp(chartrail, K_PAGEDOWN_TRAIL) == 0)  && filePtr != NULL )  {
       if (currentLine + displayLength < scrollLimit) currentLine = currentLine + displayLength;
       else currentLine = scrollLimit;
-	if (currentColumn > 1) cleanArea(1);
-	scroll(filePtr);
+    if (currentColumn > 1) cleanArea(1);
+    scroll(filePtr);
      } else if((strcmp(chartrail, K_PAGEUP_TRAIL) == 0)  && filePtr != NULL ) {
        if (currentLine - displayLength > 1) currentLine = currentLine - displayLength;
- 	else currentLine = 0;
-	if (currentColumn > 1) cleanArea(1);
-	scroll(filePtr);
+    else currentLine = 0;
+    if (currentColumn > 1) cleanArea(1);
+    scroll(filePtr);
      } else if((strcmp(chartrail, K_HOME_TRAIL) == 0 ||
-	      strcmp(chartrail, K_HOME_TRAIL2) == 0)  && filePtr != NULL ) {
-	currentLine = 0;
-	if (currentColumn > 1) cleanArea(1);
-	scroll(filePtr);
+          strcmp(chartrail, K_HOME_TRAIL2) == 0)  && filePtr != NULL ) {
+    currentLine = 0;
+    if (currentColumn > 1) cleanArea(1);
+    scroll(filePtr);
      } else if((strcmp(chartrail, K_END_TRAIL) == 0 ||
-	      strcmp(chartrail, K_END_TRAIL2) == 0)  && filePtr != NULL ) {
-	currentLine = scrollLimit;
-	if (currentColumn > 1) cleanArea(1);
-	scroll(filePtr);
+          strcmp(chartrail, K_END_TRAIL2) == 0)  && filePtr != NULL ) {
+    currentLine = scrollLimit;
+    if (currentColumn > 1) cleanArea(1);
+    scroll(filePtr);
      } else if(strcmp(chartrail, K_ALT_F) == 0) {
       data.index=FILE_MENU;
-      drop_down(&kglobal);	//animation   
+      drop_down(&kglobal);  //animation
     } else if(strcmp(chartrail, K_ALT_H) == 0) {
       data.index=HELP_MENU;
-      drop_down(&kglobal);	//animation  
+      drop_down(&kglobal);  //animation
     } else if(strcmp(chartrail, K_ALT_I) == 0) {
       filetoDisplay(filePtr, 0);
       fileInfoDialog();
@@ -399,7 +399,7 @@ int special_keys(char ch) {
         strcpy(currentPath, openFileData.fullPath);
         strcpy(fwfileName, openFileData.path);
         handleopenFile(&filePtr, fwfileName);
-	update_indicators(); 
+    update_indicators();
       }
     }
   }
@@ -419,7 +419,7 @@ int handleopenFile(FILE ** filePtr, char *fwfileName) {
   //Check for binary characters to determine filetype
   //checkF = checkFile(*filePtr);
   linesinFile = countLinesFile(*filePtr);
-  
+
   if (linesinFile > displayLength) scrollActive = 1;
     else scrollActive = 0;
 
@@ -438,50 +438,50 @@ void filetoDisplay(FILE *filePtr, int scupdate){
   char    ch;
   time_t  mytime = time(NULL);
   char   *time_str = ctime(&mytime);
-//Update screen buffer 
+//Update screen buffer
 
 if (filePtr != NULL) {
     cleanArea(0);
-    rewind(filePtr);		//Make sure we are at the beginning
+    rewind(filePtr);        //Make sure we are at the beginning
     whereinfile=gotoLine(filePtr,currentLine);
     if (whereinfile>1) fseek(filePtr, whereinfile, 0);
     while (!feof(filePtr)) {
-	  ch = getc(filePtr);	
-	  wherex = labs(i-currentColumn);
+      ch = getc(filePtr);
+      wherex = labs(i-currentColumn);
           if (ch != END_LINE_CHAR && ch != '\0') {
-		if (ch==9){ //for convenience TAB char is shown in green
-			 //with horizontal scroll
-			 if (i> currentColumn) write_ch(wherex,lineCounter+4,'>',BH_GREEN,F_WHITE);
-			 i++;
-		} else if (ch==13){
-		//windows 0x0d is transform to 0x20 
-		  ch=32;
-		}
- 		else{
-		  if (i> currentColumn) write_ch(wherex,lineCounter+4,ch,BH_BLUE,F_WHITE);
-		  i++;
-		}
-	  }
-	  if(ch == END_LINE_CHAR) { 
-		//next line
-	    for (k=i; k<scW; k++){
-		write_ch(k,lineCounter+4,' ',BH_BLUE,F_BLUE);
-		}
-	    lineCounter++;
-	    i=1;
-	  }
-	//break when it reaches end of vertical displaying area
-	  if (lineCounter > scH-6) break;
+        if (ch==9){ //for convenience TAB char is shown in green
+             //with horizontal scroll
+             if (i> currentColumn) write_ch(wherex,lineCounter+4,'>',BH_GREEN,F_WHITE);
+             i++;
+        } else if (ch==13){
+        //windows 0x0d is transform to 0x20
+          ch=32;
+        }
+        else{
+          if (i> currentColumn) write_ch(wherex,lineCounter+4,ch,BH_BLUE,F_WHITE);
+          i++;
+        }
+      }
+      if(ch == END_LINE_CHAR) {
+        //next line
+        for (k=i; k<scW; k++){
+        write_ch(k,lineCounter+4,' ',BH_BLUE,F_BLUE);
+        }
+        lineCounter++;
+        i=1;
+      }
+    //break when it reaches end of vertical displaying area
+      if (lineCounter > scH-6) break;
     }
     //to delete the last 0x0A character on screen
     write_ch(i-1,lineCounter+4,' ',BH_BLUE,F_BLUE);
   //display metrics
-  write_str(1,scH-1,"- Lines:         | - Progress:    %  | - H:    /500", B_BLACK, F_WHITE); 
+  write_str(1,scH-1,"- Lines:         | - Progress:    %  | - H:    /500", B_BLACK, F_WHITE);
   progress = ((double) currentLine / (double) scrollLimit) * 100;
-  write_num(10,scH-1,linesinFile,10, B_BLACK, F_YELLOW); 
-  if (scrollActive ==1) write_num(32,scH-1,(int)progress,3, B_BLACK, F_YELLOW); 
-  else  write_num(32,scH-1,100,3, B_BLACK, F_YELLOW);  
-  write_num(45,scH-1,currentColumn,3, B_BLACK, F_YELLOW); 
+  write_num(10,scH-1,linesinFile,10, B_BLACK, F_YELLOW);
+  if (scrollActive ==1) write_num(32,scH-1,(int)progress,3, B_BLACK, F_YELLOW);
+  else  write_num(32,scH-1,100,3, B_BLACK, F_YELLOW);
+  write_num(45,scH-1,currentColumn,3, B_BLACK, F_YELLOW);
   //display system time
   time_str[strlen(time_str) - 1] = '\0';
   write_str(scW - strlen(time_str),2,time_str,B_WHITE,F_BLACK);
@@ -500,44 +500,44 @@ void scroll(FILE *filePtr){
   int wherex = 0;
 if (filePtr != NULL) {
     //RAW output for smoother scroll
-    rewind(filePtr);		//Make sure we are at the beginning
+    rewind(filePtr);        //Make sure we are at the beginning
     whereinfile=gotoLine(filePtr,currentLine);
     if (whereinfile >1) fseek(filePtr, whereinfile, 0);
 
       while (!feof(filePtr)) {
-	  ch = getc(filePtr);
-	  outputcolor(F_WHITE,BH_BLUE);
-	  wherex = labs(i-currentColumn); 
+      ch = getc(filePtr);
+      outputcolor(F_WHITE,BH_BLUE);
+      wherex = labs(i-currentColumn);
           if (wherex < scW-1) gotoxy(labs(i-currentColumn),lineCounter+4);
           if (ch != END_LINE_CHAR && ch != '\0') {
-		if (ch==9){
-			//for convenience TAB char is shown in green
-	  		outputcolor(F_WHITE,BH_GREEN);
-			if (i> currentColumn) printf(">");
-			i++;
-		} else if (ch==13){
-		  //windows 0x0d0a transformed to 0x20 
-		   ch = 32;
-		} else{
-		    //currenColumn is for horizontal scroll
-			if (i> currentColumn) {
-				printf("%c",ch);}
-		i++;
-		} 
-	  }
-	  if(ch == END_LINE_CHAR) { 
-	   //next line
-	   printf("%c",32);
-	   for (k=i; k<=scW; k++){	
-    		outputcolor(F_BLUE,BH_BLUE);
-		gotoxy(k,lineCounter+4);
-		printf("%c",32);
-		}
-	    lineCounter++;
-	    i=1;
-	  }
-	//break when it reaches the end of vertical displaying area
-	  if (lineCounter > scH-6) break;
+        if (ch==9){
+            //for convenience TAB char is shown in green
+            outputcolor(F_WHITE,BH_GREEN);
+            if (i> currentColumn) printf(">");
+            i++;
+        } else if (ch==13){
+          //windows 0x0d0a transformed to 0x20
+           ch = 32;
+        } else{
+            //currenColumn is for horizontal scroll
+            if (i> currentColumn) {
+                printf("%c",ch);}
+        i++;
+        }
+      }
+      if(ch == END_LINE_CHAR) {
+       //next line
+       printf("%c",32);
+       for (k=i; k<=scW; k++){
+            outputcolor(F_BLUE,BH_BLUE);
+        gotoxy(k,lineCounter+4);
+        printf("%c",32);
+        }
+        lineCounter++;
+        i=1;
+      }
+    //break when it reaches the end of vertical displaying area
+      if (lineCounter > scH-6) break;
     }
   //delete last 0x0a
   gotoxy(i-1,lineCounter+4);
@@ -550,16 +550,16 @@ if (filePtr != NULL) {
   progress = ((double) currentLine / (double) scrollLimit) * 100;
   gotoxy(10,scH-1);
   outputcolor(F_YELLOW,B_BLACK);
-  printf("%ld", linesinFile); 
+  printf("%ld", linesinFile);
   gotoxy(32,scH-1);
-  outputcolor(F_YELLOW,B_BLACK); 
+  outputcolor(F_YELLOW,B_BLACK);
   if (scrollActive == 1) printf("%d", (int)progress);
-  else printf("100"); 
+  else printf("100");
   gotoxy(45,scH-1);
   outputcolor(F_YELLOW,B_BLACK);
-  printf("%d", currentColumn); 
- 
-} 
+  printf("%d", currentColumn);
+
+}
 }
 
 //clean viewing area
@@ -568,15 +568,15 @@ int i,j;
    if (raw == 1) {
    for(j=4; j<scH-1;j++)
         for (i=1; i<=scW; i++){
-    	  outputcolor(F_BLUE,BH_BLUE);
-	  gotoxy(i,j);
-  	  printf("%c",32);
+          outputcolor(F_BLUE,BH_BLUE);
+      gotoxy(i,j);
+      printf("%c",32);
         }
    }
    else{
    for(j=4; j<scH-1;j++)
         for (i=1; i<=scW; i++){
-    	  write_ch(i,j,' ',F_BLUE,BH_BLUE);
+          write_ch(i,j,' ',F_BLUE,BH_BLUE);
         }
 }
 }
@@ -590,53 +590,53 @@ char *ok=NULL;
       //open file in arguments
       clearString(currentPath, MAX_TEXT);
       strcpy(fwfileName, argv[1]);
-      ok=getcwd(currentPath, sizeof(currentPath));	//Get path
+      ok=getcwd(currentPath, sizeof(currentPath));  //Get path
       strcat(currentPath, "/");
       strcat(currentPath, argv[1]);
-      handleopenFile(&filePtr, fwfileName); 
-    } else {	      
+      handleopenFile(&filePtr, fwfileName);
+    } else {
       //display open file dialog if file does not exist
       strcpy(currentPath, "\0");
       openFileDialog(&openFileData);
       if (strcmp(openFileData.path, "\0") != 0 && file_exists(openFileData.path)){
         strcpy(currentPath, openFileData.fullPath);
         strcpy(fwfileName, openFileData.path);
-        handleopenFile(&filePtr, fwfileName); 
+        handleopenFile(&filePtr, fwfileName);
       } else
       {
-	//no file selected or file does not exist
+    //no file selected or file does not exist
         strcpy(currentPath, "No file open!");
         strcpy(fwfileName, "No file open!");
       }
      }
     } else{
-	//display open file dialog if no arguments are given
+    //display open file dialog if no arguments are given
       strcpy(currentPath, "\0");
       openFileDialog(&openFileData);
       if (strcmp(openFileData.path, "\0") != 0 && file_exists(openFileData.path)){
         strcpy(currentPath, openFileData.fullPath);
         strcpy(fwfileName, openFileData.path);
-        handleopenFile(&filePtr, fwfileName); 
+        handleopenFile(&filePtr, fwfileName);
       } else
       {
-	//no file selected or file does not exist
+    //no file selected or file does not exist
         strcpy(currentPath, "No file open!");
         strcpy(fwfileName, "No file open!");
       }
     }
    if (strcmp(currentPath,"\0") == 0) {
-  	write_str(1,3,"No file open!",B_BLACK,F_WHITE);
+    write_str(1,3,"No file open!",B_BLACK,F_WHITE);
     } else
     {
-	write_str(14,2,fwfileName,B_WHITE,F_BLACK);
-	write_str(1,3,currentPath,B_BLACK,F_WHITE);
+    write_str(14,2,fwfileName,B_WHITE,F_BLACK);
+    write_str(1,3,currentPath,B_BLACK,F_WHITE);
    }
   update_screen();
   return ok;
 }
 
-long checkScrollValues(){
-	return (linesinFile - displayLength);
+long checkScrollValues(void){
+    return (linesinFile - displayLength);
 }
 
 /* --------------------------------------*/
@@ -648,7 +648,7 @@ long checkScrollValues(){
 /* Display horizontal menu  */
 /*--------------------------*/
 
-char horizontal_menu() {
+char horizontal_menu(void) {
   char    temp_char;
   kglobal=-1;
   loadmenus(mylist, HOR_MENU);
@@ -665,14 +665,14 @@ char horizontal_menu() {
 /* Display File menu       */
 /*-------------------------*/
 
-void filemenu() {  
+void filemenu() {
   int i=0;
   data.index = OPTION_NIL;
   loadmenus(mylist, FILE_MENU);
   write_str(1, 2, "File", MENU_SELECTOR, MENU_FOREGROUND1);
   draw_window(1, 3, 13, 9, MENU_PANEL, MENU_FOREGROUND0,0, 1,0);
   for (i=2; i<13; i++)
-	write_ch(i,7,NHOR_LINE,B_WHITE,F_BLACK);
+    write_ch(i,7,NHOR_LINE,B_WHITE,F_BLACK);
   kglobal = start_vmenu(&data);
   close_window();
   update_indicators();
@@ -693,31 +693,31 @@ void filemenu() {
         strcpy(currentPath, openFileData.fullPath);
         strcpy(fwfileName, openFileData.path);
         handleopenFile(&filePtr, fwfileName);
-	update_indicators(); 
+    update_indicators();
       }
   }
   if(data.index == OPTION_2) {
-	setfile();
+    setfile();
   }
   if(data.index == OPTION_4) {
-	status = -1;
+    status = -1;
   }
   data.index = OPTION_NIL;
 }
 
-char *setfile(){
+char *setfile(void){
+    char *ok=NULL;
+    int count=0;
+    char tempFile[MAX_TEXT];
 
-char *ok=NULL;
-int count=0;
- char tempFile[MAX_TEXT];
-   count = inputWindow("New File:", tempFile, "Set file name");
+    count = inputWindow("New File:", tempFile, "Set file name");
     if(count > 0) {
      cleanString(currentPath, MAX_TEXT1);
      cleanString(fwfileName, MAX_TEXT2);
      strcpy(fwfileName, tempFile);
      if (file_exists(fwfileName)){
        handleopenFile(&filePtr, fwfileName);
-       ok=getcwd(currentPath, sizeof(currentPath));	//Get path
+       ok=getcwd(currentPath, sizeof(currentPath)); //Get path
        strcat(currentPath, "/");
        strcat(currentPath, fwfileName);
      } else
@@ -730,7 +730,7 @@ int count=0;
        filePtr = NULL;
        scrollActive = 0;
        cleanArea(0);
-       displayLogo = 1; 
+       displayLogo = 1;
        main_screen();
      }
      update_indicators();
@@ -741,7 +741,7 @@ int count=0;
 /* Display Help menu        */
 /*--------------------------*/
 
-void helpmenu() { 
+void helpmenu() {
 
   data.index = OPTION_NIL;
   loadmenus(mylist, HELP_MENU);
@@ -770,34 +770,34 @@ void helpmenu() {
 /*----------------------*/
 
 void drop_down(char *kglobal) {
-/* 
-   Drop_down loop animation. 
+/*
+   Drop_down loop animation.
    K_LEFTMENU/K_RIGHTMENU -1 is used when right/left arrow keys are used
    so as to break vertical menu and start the adjacent menu
    kglobal is changed by the menu functions.
 */
   do {
     if(*kglobal == K_ESCAPE) {
-      //Exit drop-down menu with ESC           
+      //Exit drop-down menu with ESC
       *kglobal = 0;
       break;
     }
     if(data.index == FILE_MENU) {
       filemenu();
       if(*kglobal == K_LEFTMENU) {
-	data.index = HELP_MENU;
+        data.index = HELP_MENU;
       }
       if(*kglobal == K_RIGHTMENU) {
-	data.index = HELP_MENU;
+        data.index = HELP_MENU;
       }
     }
     if(data.index == HELP_MENU) {
       helpmenu();
       if(*kglobal == K_LEFTMENU) {
-	data.index = FILE_MENU;
+        data.index = FILE_MENU;
       }
       if(*kglobal == K_RIGHTMENU) {
-	data.index = FILE_MENU;
+        data.index = FILE_MENU;
       }
     }
   } while(*kglobal != K_ENTER);
@@ -807,7 +807,7 @@ void drop_down(char *kglobal) {
 /* File Info Dialog */
 /*------------------*/
 
-int fileInfoDialog() {
+int fileInfoDialog(void) {
   long    size = 0, lines = 0;
   int     i;
   char    sizeStr[20];
@@ -843,7 +843,7 @@ int fileInfoDialog() {
   return 0;
 }
 
-void about_info(){
+void about_info(void){
   char    msg[200];
   msg[0] = '\0';
   strcat(msg, ALINE1);
@@ -853,21 +853,21 @@ void about_info(){
   alertWindow(mylist, msg,"ABOUT");
 
 }
-int help_info() {
+int help_info(void) {
   int     ok = 0;
   char    msg[500];
   msg[0] = '\0';
-  strcat(msg, HELP1);		//located in user_inter.h
-  strcat(msg, HELP2);		//located in user_inter.h
-  strcat(msg, HELP3);		//located in user_inter.h
-  strcat(msg, HELP4);		//located in user_inter.h
-  strcat(msg, HELP5);		//located in user_inter.h
-  strcat(msg, HELP6);		//located in user_inter.h
-  strcat(msg, HELP7);		//located in user_inter.h
-  strcat(msg, HELP8);		//located in user_inter.h
-  strcat(msg, HELP9);		//located in user_inter.h
-  strcat(msg, HELP10);		//located in user_inter.h
-  strcat(msg, HELP11);		//located in user_inter.h
+  strcat(msg, HELP1);       //located in user_inter.h
+  strcat(msg, HELP2);       //located in user_inter.h
+  strcat(msg, HELP3);       //located in user_inter.h
+  strcat(msg, HELP4);       //located in user_inter.h
+  strcat(msg, HELP5);       //located in user_inter.h
+  strcat(msg, HELP6);       //located in user_inter.h
+  strcat(msg, HELP7);       //located in user_inter.h
+  strcat(msg, HELP8);       //located in user_inter.h
+  strcat(msg, HELP9);       //located in user_inter.h
+  strcat(msg, HELP10);      //located in user_inter.h
+  strcat(msg, HELP11);      //located in user_inter.h
   strcat(msg, "\0");
   helpWindow(mylist, msg, "HELP");
   refresh_screen();
@@ -878,7 +878,7 @@ int help_info() {
 //CREDITS
 /* --------------------------------------*/
 
-void credits(){
+void credits(void){
 NTIMER mytimer1;
 int i=0, j=0;
 char cmsg[31] = "\nFile vieWer. Coded by v3l0r3k\n";
@@ -891,8 +891,8 @@ char cmsg[31] = "\nFile vieWer. Coded by v3l0r3k\n";
   cleanArea(1);
  if (displayLogo ==1){
   for (i=0; i<ABOUT_LINES; i++){
-	outputcolor(F_WHITE, BH_BLUE);
-	gotoxy((scW/2) - (80/2), ((scH/2) - (ABOUT_LINES/2)) + i);
+    outputcolor(F_WHITE, BH_BLUE);
+    gotoxy((scW/2) - (80/2), ((scH/2) - (ABOUT_LINES/2)) + i);
         printf("%s",about_msg[i]);
   }
  }
@@ -900,39 +900,39 @@ char cmsg[31] = "\nFile vieWer. Coded by v3l0r3k\n";
  resetTerm();
  outputcolor(B_BLUE,F_WHITE);
  gotoxy(((scW/2)-10),1);
- printf("%s\n",msg); 
+ printf("%s\n",msg);
 
  outputcolor(B_BLACK,F_BLACK);
  gotoxy(1,scH-2);
  for (i=0; i<scW;i++)
-	printf(" ");
+    printf(" ");
  gotoxy(1,scH-1);
  for (i=0; i<scW;i++)
-	printf(" ");
+    printf(" ");
  gotoxy(1,scH);
  for (i=0; i<scW;i++)
-	printf(" ");
+    printf(" ");
 
  i=0;
  j=0;
- 
+
  do{
-  if (timerC(&mytimer1) == 1) { 
+  if (timerC(&mytimer1) == 1) {
      if (mytimer1.ticks<23){
       outputcolor(F_WHITE,B_BLACK);
-      gotoxy(i,scH-2); 
-      if (i<30) printf("%c\n",cmsg[i]);      
+      gotoxy(i,scH-2);
+      if (i<30) printf("%c\n",cmsg[i]);
       i++;
      } else {
-      gotoxy(j,scH-2); 
+      gotoxy(j,scH-2);
       //outputcolor(B_BLACK,F_WHITE);
       outputcolor(FH_BLUE,B_BLACK);
       if (j<30) {
-	if (j== 1 || j== 9)  printf("%c\n",cmsg[j]);   
-        if (j> 22) {outputcolor(FH_BLACK,B_BLACK); printf("%c\n",cmsg[j]);}      
+    if (j== 1 || j== 9)  printf("%c\n",cmsg[j]);
+        if (j> 22) {outputcolor(FH_BLACK,B_BLACK); printf("%c\n",cmsg[j]);}
       }
       j++;
-      }  
+      }
  }
  } while (mytimer1.ticks<53);
   printf("\n");

--- a/opfile.c
+++ b/opfile.c
@@ -34,11 +34,11 @@
 #define FILL_CHAR 32
 
 //Keys used.
-#define K_ENTER 13 
-#define K_ENTER2 10 
+#define K_ENTER 13
+#define K_ENTER2 10
 #define K_ESCAPE 27
-#define K_UP_ARROW 'A'		// K_ESCAPE + 'A' -> UP_ARROW
-#define K_DOWN_ARROW 'B'	// K_ESCAPE + 'B' -> DOWN_ARROW
+#define K_UP_ARROW 'A'      // K_ESCAPE + 'A' -> UP_ARROW
+#define K_DOWN_ARROW 'B'    // K_ESCAPE + 'B' -> DOWN_ARROW
 //Directories
 #define CURRENTDIR "."
 #define CHANGEDIR ".."
@@ -51,44 +51,44 @@
 /* TYPEDEF STRUCTS DEFINITIONS */
 /*====================================================================*/
 typedef struct _listbox {
-  unsigned index;		// Item number
-  char   *item;			// Item string
-  char   *path;			// Item path
-  unsigned isDirectory;		// Kind of item
-  struct _listbox *next;	// Pointer to next item
-  struct _listbox *back;	// Pointer to previous item
+  unsigned index;       // Item number
+  char   *item;         // Item string
+  char   *path;         // Item path
+  unsigned isDirectory;     // Kind of item
+  struct _listbox *next;    // Pointer to next item
+  struct _listbox *back;    // Pointer to previous item
 } LISTBOX;
 
 typedef struct _scrolldata {
-  unsigned scrollActive;	//To know whether scroll is active or not.
-  unsigned scrollLimit;		//Last index for scroll.
-  unsigned listLength;		//Total no. of items in the list
-  unsigned currentListIndex;	//Pointer to new sublist of items when scrolling.
-  unsigned displayLimit;	//No. of elements to be displayed.
-  unsigned scrollDirection;	//To keep track of scrolling Direction.
+  unsigned scrollActive;    //To know whether scroll is active or not.
+  unsigned scrollLimit;     //Last index for scroll.
+  unsigned listLength;      //Total no. of items in the list
+  unsigned currentListIndex;    //Pointer to new sublist of items when scrolling.
+  unsigned displayLimit;    //No. of elements to be displayed.
+  unsigned scrollDirection; //To keep track of scrolling Direction.
   unsigned wherex;
   unsigned wherey;
-  unsigned selector;		//Y++
-  unsigned backColor0;		//0 unselected; 1 selected
+  unsigned selector;        //Y++
+  unsigned backColor0;      //0 unselected; 1 selected
   unsigned foreColor0;
   unsigned backColor1;
   unsigned foreColor1;
-  unsigned isDirectory;		// Kind of item
+  unsigned isDirectory;     // Kind of item
   char   *item;
   char   *path;
   char    fullPath[MAX];
   unsigned itemIndex;
- // LISTBOX *head;		//store head of the list
+ // LISTBOX *head;      //store head of the list
 } SCROLLDATA;
 
 /*====================================================================*/
 /* GLOBAL VARIABLES */
 /*====================================================================*/
 
-LISTBOX *listBox1 = NULL;	//Head pointer.
+LISTBOX *listBox1 = NULL;   //Head pointer.
 int     window_x1 = 0, window_y1 = 0, window_x2 = 0, window_y2 = 0;
   char    fullPath[MAX];
-  char	  fileName[MAX];
+  char    fileName[MAX];
   char    newDir[MAX];
   int scWidth, scHeight;
 /*====================================================================*/
@@ -99,14 +99,14 @@ int     window_x1 = 0, window_y1 = 0, window_x2 = 0, window_y2 = 0;
 /* Terminal manipulation routines */
 /* ------------------------------ */
 void cleanLine(int line, int backcolor, int forecolor, int startx,
-	       int numchars) {
+           int numchars) {
 //Cleans line of console.
   int     i;
   for(i = startx; i < numchars; i++) {
     //clean line where path is displayed.
     outputcolor(forecolor, backcolor);
     gotoxy(i, line);
-    printf("%c", FILL_CHAR);	//space
+    printf("%c", FILL_CHAR);    //space
   }
 }
 
@@ -129,25 +129,25 @@ LISTBOX *newelement(char *text, char *itemPath, unsigned itemType) {
   return newp;
 }
 
-void deleteList(LISTBOX **head) 
-{ 
+void deleteList(LISTBOX **head)
+{
    /* deref head_ref to get the real head */
-   LISTBOX *current = *head; 
-   LISTBOX *next = NULL; 
-  
-   while (current != NULL)  
-   { 
-       next = current->next; 
+   LISTBOX *current = *head;
+   LISTBOX *next = NULL;
+
+   while (current != NULL)
+   {
+       next = current->next;
        free(current->item);
        free(current->path);
        free(current);
-       current = next; 
-   } 
-    
-   /* deref head_ref to affect the real head back 
+       current = next;
+   }
+
+   /* deref head_ref to affect the real head back
       in the caller. */
-   *head = NULL; 
-} 
+   *head = NULL;
+}
 
 
 /* addend: add new LISTBOX to the end of a list  */
@@ -184,7 +184,7 @@ void displayItem2(LISTBOX * aux, SCROLLDATA * scrollData, int select)
       else{//First&second items are buttons
         gotoxy(scrollData->wherex, scrollData->selector);
         outputcolor(scrollData->foreColor1, B_BLACK);
-        printf("%s\n", aux->item);      
+        printf("%s\n", aux->item);
       }
       break;
 
@@ -197,14 +197,14 @@ void displayItem2(LISTBOX * aux, SCROLLDATA * scrollData, int select)
       else{ //First and second items are buttons
         gotoxy(scrollData->wherex, scrollData->selector);
         outputcolor(scrollData->foreColor0, scrollData -> backColor0);
-        printf("%s\n", aux->item);       
+        printf("%s\n", aux->item);
       }
       break;
   }
 }
 
 void gotoIndex(LISTBOX ** aux, SCROLLDATA * scrollData,
-	       unsigned indexAt)
+           unsigned indexAt)
 //Go to a specific location on the list.
 {
   LISTBOX *aux2;
@@ -241,9 +241,9 @@ in scrollData.
     displayItem2(aux, scrollData, UNSELECT_ITEM);
     aux = aux->next;
     counter++;
-    scrollData->selector++;	// wherey++
+    scrollData->selector++; // wherey++
   } while(counter != scrollData->displayLimit);
-  scrollData->selector = wherey;	//restore value
+  scrollData->selector = wherey;    //restore value
 }
 
 int query_length(LISTBOX ** head) {
@@ -263,7 +263,7 @@ int query_length(LISTBOX ** head) {
 }
 
 int move_display(LISTBOX ** selector, SCROLLDATA * scrollData) {
-/* 
+/*
 Creates animation by moving a selector highlighting next item and
 unselecting previous item
 */
@@ -309,48 +309,48 @@ unselecting previous item
       //Check whether we move UP or Down
       switch (scrollData->scrollDirection) {
 
-	case UP_SCROLL:
-	  //Calculate new top index if scroll is active 
-	  //otherwise it defaults to 0 (top)
-	  if(scrollData->scrollActive == SCROLL_ACTIVE)
-	    scrollControl = scrollData->currentListIndex;
-	  else
-	    scrollControl = 0;
+    case UP_SCROLL:
+      //Calculate new top index if scroll is active
+      //otherwise it defaults to 0 (top)
+      if(scrollData->scrollActive == SCROLL_ACTIVE)
+        scrollControl = scrollData->currentListIndex;
+      else
+        scrollControl = 0;
 
-	  //Move selector
-	  if(aux->back->index >= scrollControl) {
-	    scrollData->selector--;	//whereY--
-	    aux = aux->back;	//Go to previous item
-	  } else {
-	    if(scrollData->scrollActive == SCROLL_ACTIVE)
-	      continueScroll = 1;
-	    else
-	      continueScroll = 0;
-	  }
-	  break;
+      //Move selector
+      if(aux->back->index >= scrollControl) {
+        scrollData->selector--; //whereY--
+        aux = aux->back;    //Go to previous item
+      } else {
+        if(scrollData->scrollActive == SCROLL_ACTIVE)
+          continueScroll = 1;
+        else
+          continueScroll = 0;
+      }
+      break;
 
-	case DOWN_SCROLL:
-	  //Calculate bottom index limit if scroll is ACTIVE
-	  //Otherwise it defaults to scrollData->ListLength-1
+    case DOWN_SCROLL:
+      //Calculate bottom index limit if scroll is ACTIVE
+      //Otherwise it defaults to scrollData->ListLength-1
 
-	  if(scrollData->scrollActive == SCROLL_ACTIVE)
-	    scrollControl =
-		scrollData->currentListIndex + (scrollData->displayLimit -
-						1);
-	  else
-	    scrollControl = scrollData->listLength - 1;
+      if(scrollData->scrollActive == SCROLL_ACTIVE)
+        scrollControl =
+        scrollData->currentListIndex + (scrollData->displayLimit -
+                        1);
+      else
+        scrollControl = scrollData->listLength - 1;
 
-	  //Move selector
-	  if(aux->next->index <= scrollControl) {
-	    aux = aux->next;	//Go to next item
-	    scrollData->selector++;	//whereY++;
-	  } else {
-	    if(scrollData->scrollActive == SCROLL_ACTIVE)
-	      continueScroll = 1;
-	    else
-	      continueScroll = 0;
-	  }
-	  break;
+      //Move selector
+      if(aux->next->index <= scrollControl) {
+        aux = aux->next;    //Go to next item
+        scrollData->selector++; //whereY++;
+      } else {
+        if(scrollData->scrollActive == SCROLL_ACTIVE)
+          continueScroll = 1;
+        else
+          continueScroll = 0;
+      }
+      break;
       }
 
       //Metrics
@@ -396,7 +396,7 @@ char selectorMenu(LISTBOX * aux, SCROLLDATA * scrollData) {
 
   if(scrollData->scrollDirection == DOWN_SCROLL
      && scrollData->currentListIndex != 0) {
-    //If we are going down we'll select the last item 
+    //If we are going down we'll select the last item
     //to create a better scrolling transition (animation)
     for(counter = 0; counter < scrollData->displayLimit; counter++) {
       scrollData->scrollDirection = DOWN_SCROLL;
@@ -425,91 +425,91 @@ char selectorMenu(LISTBOX * aux, SCROLLDATA * scrollData) {
       keypressed = 0;
       //if enter key pressed - break loop
       if(ch == K_ENTER)
-        control = CONTINUE_SCROLL;	//Break the loop
+        control = CONTINUE_SCROLL;  //Break the loop
       //fail-safe keys
       if (ch == 'w'){
-	  //Move selector up
-	  scrollData->scrollDirection = UP_SCROLL;
-	  continueScroll = move_display(&aux, scrollData);
-	  //Break the loop if we are scrolling
-	  if(scrollData->scrollActive == SCROLL_ACTIVE
-	     && continueScroll == 1) {
-	    control = CONTINUE_SCROLL;
-	    //Update data
-	    scrollData->currentListIndex =
-		scrollData->currentListIndex - 1;
-	    scrollData->selector = scrollData->wherey;
-	    scrollData->itemIndex = aux->index;
-	    //Return value
-	    ch = control;
-	  }
+      //Move selector up
+      scrollData->scrollDirection = UP_SCROLL;
+      continueScroll = move_display(&aux, scrollData);
+      //Break the loop if we are scrolling
+      if(scrollData->scrollActive == SCROLL_ACTIVE
+         && continueScroll == 1) {
+        control = CONTINUE_SCROLL;
+        //Update data
+        scrollData->currentListIndex =
+        scrollData->currentListIndex - 1;
+        scrollData->selector = scrollData->wherey;
+        scrollData->itemIndex = aux->index;
+        //Return value
+        ch = control;
+      }
        }
       if (ch == 's'){
-	  //Move selector down
-	  scrollData->scrollDirection = DOWN_SCROLL;
-	  continueScroll = move_display(&aux, scrollData);
-	  //Break the loop if we are scrolling
-	  if(scrollData->scrollActive == SCROLL_ACTIVE
-	     && continueScroll == 1) {
-	    control = CONTINUE_SCROLL;
-	    //Update data  
-	    scrollData->currentListIndex =
-		scrollData->currentListIndex + 1;
-	    scrollData->selector = scrollData->wherey;
-	    scrollData->itemIndex = aux->index;
-	    scrollData->scrollDirection = DOWN_SCROLL;
-	  }
-	  //Return value  
+      //Move selector down
+      scrollData->scrollDirection = DOWN_SCROLL;
+      continueScroll = move_display(&aux, scrollData);
+      //Break the loop if we are scrolling
+      if(scrollData->scrollActive == SCROLL_ACTIVE
+         && continueScroll == 1) {
+        control = CONTINUE_SCROLL;
+        //Update data
+        scrollData->currentListIndex =
+        scrollData->currentListIndex + 1;
+        scrollData->selector = scrollData->wherey;
+        scrollData->itemIndex = aux->index;
+        scrollData->scrollDirection = DOWN_SCROLL;
+      }
+      //Return value
           ch = control;
        }
       //Check arrow keys
-      if(ch == K_ESCAPE)		// escape key
+      if(ch == K_ESCAPE)        // escape key
       {
-        read_keytrail(chartrail);	// read key again for arrow key combinations
+        read_keytrail(chartrail);   // read key again for arrow key combinations
         if(strcmp(chartrail, K_UP_TRAIL) == 0) {
-	  // escape key + A => arrow key up
-	  //Move selector up
-	  scrollData->scrollDirection = UP_SCROLL;
-	  continueScroll = move_display(&aux, scrollData);
-	  //Break the loop if we are scrolling
-	  if(scrollData->scrollActive == SCROLL_ACTIVE
-	     && continueScroll == 1) {
-	    control = CONTINUE_SCROLL;
-	    //Update data
-	    scrollData->currentListIndex =
-		scrollData->currentListIndex - 1;
-	    scrollData->selector = scrollData->wherey;
-	    scrollData->itemIndex = aux->index;
-	    //Return value
-	    ch = control;
-	  }
+      // escape key + A => arrow key up
+      //Move selector up
+      scrollData->scrollDirection = UP_SCROLL;
+      continueScroll = move_display(&aux, scrollData);
+      //Break the loop if we are scrolling
+      if(scrollData->scrollActive == SCROLL_ACTIVE
+         && continueScroll == 1) {
+        control = CONTINUE_SCROLL;
+        //Update data
+        scrollData->currentListIndex =
+        scrollData->currentListIndex - 1;
+        scrollData->selector = scrollData->wherey;
+        scrollData->itemIndex = aux->index;
+        //Return value
+        ch = control;
+      }
        }
       if(strcmp(chartrail, K_DOWN_TRAIL) == 0) {
-	// escape key + B => arrow key down
-	  //Move selector down
-	  scrollData->scrollDirection = DOWN_SCROLL;
-	  continueScroll = move_display(&aux, scrollData);
-	  //Break the loop if we are scrolling
-	  if(scrollData->scrollActive == SCROLL_ACTIVE
-	     && continueScroll == 1) {
-	    control = CONTINUE_SCROLL;
-	    //Update data  
-	    scrollData->currentListIndex =
-		scrollData->currentListIndex + 1;
-	    scrollData->selector = scrollData->wherey;
-	    scrollData->itemIndex = aux->index;
-	    scrollData->scrollDirection = DOWN_SCROLL;
-	  }
-	  //Return value  
-          ch = control;         
+    // escape key + B => arrow key down
+      //Move selector down
+      scrollData->scrollDirection = DOWN_SCROLL;
+      continueScroll = move_display(&aux, scrollData);
+      //Break the loop if we are scrolling
+      if(scrollData->scrollActive == SCROLL_ACTIVE
+         && continueScroll == 1) {
+        control = CONTINUE_SCROLL;
+        //Update data
+        scrollData->currentListIndex =
+        scrollData->currentListIndex + 1;
+        scrollData->selector = scrollData->wherey;
+        scrollData->itemIndex = aux->index;
+        scrollData->scrollDirection = DOWN_SCROLL;
+      }
+      //Return value
+          ch = control;
       }
       }
  // if (ch == K_TAB) break;
-  if(ch == K_ENTER || ch == K_ENTER2)		// enter key
+  if(ch == K_ENTER || ch == K_ENTER2)       // enter key
   {
     //Pass data of last item selected.
     //scrollData->item =
-	//(char *)imalloc(sizeof(char) * strlen(aux->item) + 1);
+    //(char *)imalloc(sizeof(char) * strlen(aux->item) + 1);
     //scrollData->path = (char *)malloc(sizeof(char) *strlen(aux->path) + 1);
     gotoxy(1,3);
     outputcolor(B_BLACK, F_BLACK);
@@ -528,10 +528,10 @@ char selectorMenu(LISTBOX * aux, SCROLLDATA * scrollData) {
 }
 
 char listBox(LISTBOX * head,
-	     unsigned whereX, unsigned whereY,
-	     SCROLLDATA * scrollData, unsigned bColor0,
-	     unsigned fColor0, unsigned bColor1, unsigned fColor1,
-	     unsigned displayLimit) {
+         unsigned whereX, unsigned whereY,
+         SCROLLDATA * scrollData, unsigned bColor0,
+         unsigned fColor0, unsigned bColor1, unsigned fColor1,
+         unsigned displayLimit) {
 
   unsigned list_length = 0;
   //unsigned currentIndex = 0;
@@ -545,10 +545,10 @@ char listBox(LISTBOX * head,
 
   //Save calculations for SCROLL and store DATA
   scrollData->displayLimit = displayLimit;
-  scrollLimit = list_length - scrollData->displayLimit;	//Careful with negative integers
+  scrollLimit = list_length - scrollData->displayLimit; //Careful with negative integers
 
   if(scrollLimit < 0)
-    scrollData->displayLimit = list_length;	//Failsafe for overboard values
+    scrollData->displayLimit = list_length; //Failsafe for overboard values
 
   scrollData->scrollLimit = scrollLimit;
   scrollData->listLength = list_length;
@@ -560,17 +560,17 @@ char listBox(LISTBOX * head,
   scrollData->foreColor0 = fColor0;
   scrollData->foreColor1 = fColor1;
 
-  //Check whether we have to activate scroll or not 
+  //Check whether we have to activate scroll or not
   //and if we are within bounds. [1,list_length)
 
   if(list_length > scrollData->displayLimit && scrollLimit > 0
      && displayLimit > 0) {
-    //Scroll is possible  
+    //Scroll is possible
 
     scrollData->scrollActive = SCROLL_ACTIVE;
     aux = head;
 
-    currentListIndex = 0;	//We listBox1 the scroll at the top index.
+    currentListIndex = 0;   //We listBox1 the scroll at the top index.
     scrollData->currentListIndex = currentListIndex;
 
     //Scroll loop animation. Finish with ENTER.
@@ -587,7 +587,7 @@ char listBox(LISTBOX * head,
     //Display all the elements and create selector.
     scrollData->scrollActive = SCROLL_INACTIVE;
     scrollData->currentListIndex = 0;
-    scrollData->displayLimit = list_length;	//Default to list_length
+    scrollData->displayLimit = list_length; //Default to list_length
     loadlist(head, scrollData, 0);
     ch = selectorMenu(head, scrollData);
   }
@@ -617,7 +617,7 @@ int listFiles(LISTBOX ** listBox1, char *directory) {
   struct dirent *dir;
   int     i;
   char    temp[MAX_ITEM_LENGTH];
-  int     lenDir;		//length of directory
+  int     lenDir;       //length of directory
 
   //Add elements to switch directory at the beginning for convenience.
   strcpy(temp, "[CLOSE WINDOW]");
@@ -633,7 +633,7 @@ int listFiles(LISTBOX ** listBox1, char *directory) {
   strcpy(temp, CHANGEDIR);
   //Add spaces
   addSpaces(temp);
-  *listBox1 = addend(*listBox1, newelement(temp, CHANGEDIR, DIRECTORY));	// ".."
+  *listBox1 = addend(*listBox1, newelement(temp, CHANGEDIR, DIRECTORY));    // ".."
 
   //Start at current directory
   d = opendir(directory);
@@ -642,34 +642,34 @@ int listFiles(LISTBOX ** listBox1, char *directory) {
     while((dir = readdir(d)) != NULL) {
       if(dir->d_type == DT_DIR) {
 
-	lenDir = strlen(dir->d_name);
+    lenDir = strlen(dir->d_name);
 
-	//Check length of directory
-	//Directories are displayed between brackets [directory]
-	if(lenDir > MAX_ITEM_LENGTH - 2) {
-	  //Directory name is long. CROP
-	  cleanString(temp, MAX_ITEM_LENGTH);
-	  strcpy(temp, "[");
-	  for(i = 1; i < MAX_ITEM_LENGTH - 1; i++) {
-	    temp[i] = dir->d_name[i - 1];
-	  }
-	  temp[MAX_ITEM_LENGTH - 1] = ']';
-	} else {
-	  //Directory's name is shorter than display
-	  //Add spaces to item string.
-	  cleanString(temp, MAX_ITEM_LENGTH);
-	  strcpy(temp, "[");
-	  for(i = 1; i < lenDir + 1; i++) {
-	    temp[i] = dir->d_name[i - 1];
-	  }
-	  temp[lenDir + 1] = ']';
-	  addSpaces(temp);
-	}
-	//Add all directories except CURRENTDIR and CHANGEDIR
-	if(strcmp(dir->d_name, CURRENTDIR) != 0
-	   && strcmp(dir->d_name, CHANGEDIR) != 0)
-	  *listBox1 =
-	      addend(*listBox1, newelement(temp, dir->d_name, DIRECTORY));
+    //Check length of directory
+    //Directories are displayed between brackets [directory]
+    if(lenDir > MAX_ITEM_LENGTH - 2) {
+      //Directory name is long. CROP
+      cleanString(temp, MAX_ITEM_LENGTH);
+      strcpy(temp, "[");
+      for(i = 1; i < MAX_ITEM_LENGTH - 1; i++) {
+        temp[i] = dir->d_name[i - 1];
+      }
+      temp[MAX_ITEM_LENGTH - 1] = ']';
+    } else {
+      //Directory's name is shorter than display
+      //Add spaces to item string.
+      cleanString(temp, MAX_ITEM_LENGTH);
+      strcpy(temp, "[");
+      for(i = 1; i < lenDir + 1; i++) {
+        temp[i] = dir->d_name[i - 1];
+      }
+      temp[lenDir + 1] = ']';
+      addSpaces(temp);
+    }
+    //Add all directories except CURRENTDIR and CHANGEDIR
+    if(strcmp(dir->d_name, CURRENTDIR) != 0
+       && strcmp(dir->d_name, CHANGEDIR) != 0)
+      *listBox1 =
+          addend(*listBox1, newelement(temp, dir->d_name, DIRECTORY));
       }
     }
   }
@@ -680,19 +680,19 @@ int listFiles(LISTBOX ** listBox1, char *directory) {
   if(d) {
     while((dir = readdir(d)) != NULL) {
       if(dir->d_type == DT_REG) {
-	//only list valid fiels
-	if(strlen(dir->d_name) > MAX_ITEM_LENGTH) {
-	  for(i = 0; i < MAX_ITEM_LENGTH; i++) {
-	    temp[i] = dir->d_name[i];
-	  }
-	} else {
-	  cleanString(temp, MAX_ITEM_LENGTH);
-	  strcpy(temp, dir->d_name);
-	  //Add spaces
-	  addSpaces(temp);
-	}
-	*listBox1 =
-	    addend(*listBox1, newelement(temp, dir->d_name, FILEITEM));
+    //only list valid fiels
+    if(strlen(dir->d_name) > MAX_ITEM_LENGTH) {
+      for(i = 0; i < MAX_ITEM_LENGTH; i++) {
+        temp[i] = dir->d_name[i];
+      }
+    } else {
+      cleanString(temp, MAX_ITEM_LENGTH);
+      strcpy(temp, dir->d_name);
+      //Add spaces
+      addSpaces(temp);
+    }
+    *listBox1 =
+        addend(*listBox1, newelement(temp, dir->d_name, FILEITEM));
       }
     }
     closedir(d);
@@ -701,7 +701,7 @@ int listFiles(LISTBOX ** listBox1, char *directory) {
 }
 
 char *changeDir(SCROLLDATA * scrollData, char fullPath[MAX],
-	       char newDir[MAX]) {
+           char newDir[MAX]) {
 //Change dir
   char    oldPath[MAX];
   int ok=0;
@@ -754,12 +754,12 @@ int setFileName(char fileName[MAX]) {
 /* ---------------- */
 
 /*========================================================================*/
-/*  
-  ListBox with Scroll: 
+/*
+  ListBox with Scroll:
   ____________________
-  
+
   Usage:
-   
+
   listBox(headpointer, whereX, whereY, scrollData, backColor0, foreColor0,
 backcolor1, forecolor1, displayLimit); */
 
@@ -775,20 +775,20 @@ char *openFileDialog(SCROLLDATA * openFileData) {
   //LISTCHOICE optionHandle;
   get_terminal_dimensions(&scHeight, &scWidth);
 //init values
-  scrollData.scrollActive=0;	//To know whether scroll is active or not.
-  scrollData.scrollLimit=0;		//Last index for scroll.
-  scrollData.listLength=0;		//Total no. of items in the list
-  scrollData.currentListIndex=0;	//Pointer to new sublist of items when scrolling.
-  scrollData.displayLimit=0;	//No. of elements to be displayed.
-  scrollData.scrollDirection=0;	//To keep track of scrolling Direction.
-  scrollData.selector=0;		//Y++
-  scrollData.wherex=0;		
-  scrollData.wherey=0;		
-  scrollData.backColor0=0;		//0 unselected; 1 selected
+  scrollData.scrollActive=0;    //To know whether scroll is active or not.
+  scrollData.scrollLimit=0;     //Last index for scroll.
+  scrollData.listLength=0;      //Total no. of items in the list
+  scrollData.currentListIndex=0;    //Pointer to new sublist of items when scrolling.
+  scrollData.displayLimit=0;    //No. of elements to be displayed.
+  scrollData.scrollDirection=0; //To keep track of scrolling Direction.
+  scrollData.selector=0;        //Y++
+  scrollData.wherex=0;
+  scrollData.wherey=0;
+  scrollData.backColor0=0;      //0 unselected; 1 selected
   scrollData.foreColor0=0;
   scrollData.backColor1=0;
   scrollData.foreColor1=0;
-  scrollData.isDirectory=0;		// Kind of item
+  scrollData.isDirectory=0;     // Kind of item
   scrollData.item =NULL;
   scrollData.path =NULL;
   scrollData.itemIndex=0;
@@ -802,53 +802,53 @@ char *openFileDialog(SCROLLDATA * openFileData) {
 
   //Change background color
 
-  strcpy(newDir, ".");		//We start at current dir
-  ok1= getcwd(fullPath, sizeof(fullPath));	//Get path
+  strcpy(newDir, ".");      //We start at current dir
+  ok1= getcwd(fullPath, sizeof(fullPath));  //Get path
 
   //Directories loop
   draw_window(window_x1, window_y1, window_x2, window_y2, MENU_PANEL, MENU_FOREGROUND0, WINDOW_TITLEB,1,1);
-  write_str((window_x2-window_x1) /2 + window_x1 - (strlen("OPEN FILE DIALOG")/2) , window_y1-1, "OPEN FILE DIALOG", WINDOW_TITLEB, WINDOW_TITLEF);	
+  write_str((window_x2-window_x1) /2 + window_x1 - (strlen("OPEN FILE DIALOG")/2) , window_y1-1, "OPEN FILE DIALOG", WINDOW_TITLEB, WINDOW_TITLEF);
   update_screen();
- 
+
    do {
     //Add items to list
     listFiles(&listBox1, newDir);
     ch = listBox(listBox1, window_x1 + 2, window_y1 + 1, &scrollData,
-		 B_WHITE, F_BLACK, MENU_SELECTOR, MENU_FOREGROUND1, 15);
-        
+         B_WHITE, F_BLACK, MENU_SELECTOR, MENU_FOREGROUND1, 15);
+
 
     //Scroll Loop exit conditions
     if(scrollData.itemIndex == 0)
-      exitFlag = 1;		//First item is selected
+      exitFlag = 1;     //First item is selected
 
     //Second item is selected - set file
     if(scrollData.itemIndex == 1)
     {
         close_window();
         ok = setFileName(fileName);
-	if (ok==1) {
-	   //Let's send data to main module
-	    strcpy(scrollData.item, "\0");
-	    strcpy(scrollData.item, fileName);
-	    strcpy(scrollData.path, "\0");
-	    strcpy(scrollData.path, fileName);
-	}     
-	
-   	    exitFlag = 1;
+    if (ok==1) {
+       //Let's send data to main module
+        strcpy(scrollData.item, "\0");
+        strcpy(scrollData.item, fileName);
+        strcpy(scrollData.path, "\0");
+        strcpy(scrollData.path, fileName);
+    }
+
+        exitFlag = 1;
     } else
     {
       //Change Dir. New directory is copied in newDir
 
       changeDir(&scrollData, fullPath, newDir);
     }
-    
+
     //Clean all lines on the window
     for(i = window_y1 + 3; i < window_y2; i++) {
       cleanLine(i, B_WHITE, F_WHITE, window_x1 + 1, window_x2);
     }
 
     if(ch == K_ENTER && scrollData.isDirectory == FILEITEM)
-      exitFlag = 1;		//File selected
+      exitFlag = 1;     //File selected
     //if (ch == K_TAB) break;
     openFileData->item = scrollData.item;
     openFileData->itemIndex = scrollData.itemIndex;
@@ -860,9 +860,9 @@ char *openFileDialog(SCROLLDATA * openFileData) {
     openFileData->isDirectory = scrollData.isDirectory;
 
     if(listBox1 != NULL && exitFlag != 1) {
-		deleteList(&listBox1);
-		listBox1 = NULL;
-    } 
+        deleteList(&listBox1);
+        listBox1 = NULL;
+    }
   } while(exitFlag != 1);
 
   //Return file selected by copying into fileToOpen -> currentFile

--- a/opfile.h
+++ b/opfile.h
@@ -1,11 +1,11 @@
 /*
 ========================================================================
-- HEADER - 
-Module to open a file by showing a dialogue that allows you to navigate 
+- HEADER -
+Module to open a file by showing a dialogue that allows you to navigate
 through directories with a list with scroll.
 @author : Velorek
-@version : 1.0  
-Last modified: 14/04/2019 Rename headers                                                                
+@version : 1.0
+Last modified: 14/04/2019 Rename headers
 ========================================================================
 */
 
@@ -31,34 +31,34 @@ Last modified: 14/04/2019 Rename headers
 /* TYPEDEF STRUCTS DEFINITIONS */
 /*====================================================================*/
 typedef struct _listbox {
-  unsigned index;		// Item number
-  char   *item;			// Item string
-  char   *path;			// Item path
-  unsigned isDirectory;		// Kind of item
-  struct _listchoice *next;	// Pointer to next item
-  struct _listchoice *back;	// Pointer to previous item
+  unsigned index;       // Item number
+  char   *item;         // Item string
+  char   *path;         // Item path
+  unsigned isDirectory;     // Kind of item
+  struct _listchoice *next; // Pointer to next item
+  struct _listchoice *back; // Pointer to previous item
 } LISTBOX;
 
 typedef struct _scrolldata {
-  unsigned scrollActive;	//To know whether scroll is active or not.
-  unsigned scrollLimit;		//Last index for scroll.
-  unsigned listLength;		//Total no. of items in the list
-  unsigned currentListIndex;	//Pointer to new sublist of items when scrolling.
-  unsigned displayLimit;	//No. of elements to be displayed.
-  unsigned scrollDirection;	//To keep track of scrolling Direction.
+  unsigned scrollActive;    //To know whether scroll is active or not.
+  unsigned scrollLimit;     //Last index for scroll.
+  unsigned listLength;      //Total no. of items in the list
+  unsigned currentListIndex;    //Pointer to new sublist of items when scrolling.
+  unsigned displayLimit;    //No. of elements to be displayed.
+  unsigned scrollDirection; //To keep track of scrolling Direction.
   unsigned wherex;
   unsigned wherey;
-  unsigned selector;		//Y++
-  unsigned backColor0;		//0 unselected; 1 selected
+  unsigned selector;        //Y++
+  unsigned backColor0;      //0 unselected; 1 selected
   unsigned foreColor0;
   unsigned backColor1;
   unsigned foreColor1;
-  unsigned isDirectory;		// Kind of item
+  unsigned isDirectory;     // Kind of item
   char   *item;
   char   *path;
   char    fullPath[MAX];
   unsigned itemIndex;
-  LISTBOX *head;		//store head of the list
+  LISTBOX *head;        //store head of the list
 } SCROLLDATA;
 
 /*====================================================================*/
@@ -69,9 +69,9 @@ typedef struct _scrolldata {
 /* FUNCTION PROTOTYPES                                                */
 /*====================================================================*/
 
-//CONSOLE DISPLAY FUNCTIONS 
+//CONSOLE DISPLAY FUNCTIONS
 void    cleanLine(int line, int backcolor, int forecolor, int startx,
-		  int numchars);
+          int numchars);
 
 //DYNAMIC LINKED LIST FUNCTIONS
 void    deleteList(LISTBOX ** head);
@@ -80,14 +80,14 @@ LISTBOX *newelement(char *text, char *itemPath, unsigned itemType);
 
 //LISTBOX FUNCTIONS
 char    listBox(LISTBOX * selector, unsigned whereX, unsigned whereY,
-		SCROLLDATA * scrollData, unsigned bColor0,
-		unsigned fColor0, unsigned bColor1, unsigned fColor1,
-		unsigned displayLimit);
+        SCROLLDATA * scrollData, unsigned bColor0,
+        unsigned fColor0, unsigned bColor1, unsigned fColor1,
+        unsigned displayLimit);
 void    loadlist(LISTBOX * head, SCROLLDATA * scrollData,
-		 unsigned indexAt);
+         unsigned indexAt);
 
 void    gotoIndex(LISTBOX ** aux, SCROLLDATA * scrollData,
-		  unsigned indexAt);
+          unsigned indexAt);
 int     query_length(LISTBOX ** head);
 int     move_display(LISTBOX ** head, SCROLLDATA * scrollData);
 char    selectorMenu(LISTBOX * aux, SCROLLDATA * scrollData);
@@ -98,9 +98,9 @@ int     listFiles(LISTBOX ** listBox1, char *directory);
 int     addSpaces(char temp[MAX_ITEM_LENGTH]);
 void    cleanString(char *string, int max);
 char   *changeDir(SCROLLDATA * scrollData, char fullPath[MAX],
-		  char newDir[MAX]);
+          char newDir[MAX]);
 //OPEN FILE DIALOG
 char   *openFileDialog(SCROLLDATA * openFileData);
-int	setFileName(char fileName[MAX]);
+int setFileName(char fileName[MAX]);
 
 #endif

--- a/rterm.c
+++ b/rterm.c
@@ -1,10 +1,10 @@
-/* 
+/*
 ======================================================================
 Module to control some display routines that implement ANSI functions.
 
 @author : Velorek
 @version : 1.0
- 
+
 LAST MODIFIED : 14/04/2019 Rename Headers
 ======================================================================
 */
@@ -34,7 +34,7 @@ static int peek_character = -1;
 /*-------------------------------------*/
 /* Initialize new terminal i/o settings*/
 /*-------------------------------------*/
-void pushTerm() {
+void pushTerm(void) {
 //Save terminal settings in failsafe to be retrived at the end
   tcgetattr(0, &failsafe);
 }
@@ -42,7 +42,7 @@ void pushTerm() {
 /*---------------------------*/
 /* Reset terminal to failsafe*/
 /*---------------------------*/
-int resetTerm() {
+int resetTerm(void) {
   //tcsetattr(0, TCSANOW, &failsafe);
   /* flush and reset */
   if (tcsetattr(0,TCSAFLUSH,&failsafe) < 0) return -1;
@@ -54,7 +54,7 @@ int resetTerm() {
 /* Detect whether a key has been pressed.*/
 /*---------------------------------------*/
 
-int kbhit()
+int kbhit(void)
 {
     if(peek_character != -1)
     return 1;
@@ -74,7 +74,7 @@ int kbhit()
 /*----------------------*/
 /*Read char with control*/
 /*----------------------*/
-int readch() {
+int readch(void) {
   char    ch;
   int ret=0;
  if(peek_character != -1) {
@@ -87,8 +87,8 @@ int readch() {
   return ch;
 }
 
-void resetch() {
-//Clear ch  
+void resetch(void) {
+//Clear ch
   term.c_cc[VMIN] = 0;
   tcsetattr(0, TCSANOW, &term);
   peek_character = 0;
@@ -137,16 +137,16 @@ void screencol(int x) {
 /*-----------------------*/
 void resetAnsi(int x) {
   switch (x) {
-    case 0:			//reset all colors and attributes
+    case 0:         //reset all colors and attributes
       printf("%c[0m", 0x1b);
       break;
-    case 1:			//reset only attributes
+    case 1:         //reset only attributes
       printf("%c[20m", 0x1b);
       break;
-    case 2:			//reset foreg. colors and not attrib.
+    case 2:         //reset foreg. colors and not attrib.
       printf("%c[39m", 0x1b);
       break;
-    case 3:			//reset back. colors and not attrib.
+    case 3:         //reset back. colors and not attrib.
       printf("%c[49m", 0x1b);
       break;
     default:
@@ -167,13 +167,13 @@ int get_terminal_dimensions(int *rows, int *columns) {
 /*--------------------------*/
 /* Ansi function hide cursor*/
 /*--------------------------*/
-void hidecursor() {
+void hidecursor(void) {
   printf("\e[?25l");
 }
 
 /*--------------------------*/
 /* Ansi function show cursor*/
 /*--------------------------*/
-void showcursor() {
+void showcursor(void) {
   printf("\e[?25h");
 }

--- a/rterm.h
+++ b/rterm.h
@@ -1,10 +1,10 @@
 /*
 ========================================================================
-- HEADER - 
+- HEADER -
 Module to control some display routines that implement ANSI functions.
 @author : Velorek
-@version : 1.0  
-Last modified: 14/04/2019 + Rename headers                                                                
+@version : 1.0
+Last modified: 14/04/2019 + Rename headers
 ========================================================================
 */
 
@@ -25,7 +25,7 @@ Last modified: 14/04/2019 + Rename headers
 /* COLOR CONSTANTS                                                    */
 /*====================================================================*/
 
-// Background colors low intensity                                                                         
+// Background colors low intensity
 #define B_BLACK 40
 #define B_RED 41
 #define B_GREEN 42
@@ -35,7 +35,7 @@ Last modified: 14/04/2019 + Rename headers
 #define B_CYAN 46
 #define B_WHITE 47
 
-// Foreground colors low intensity                                                                                                                                 
+// Foreground colors low intensity
 #define F_BLACK 30
 #define F_RED 31
 #define F_GREEN 32
@@ -47,7 +47,7 @@ Last modified: 14/04/2019 + Rename headers
 //#define F_WHITE 37
 #define F_GREY 90
 
-// Background colors high intensity                                                                                                                                     
+// Background colors high intensity
 #define BH_BLACK 100
 #define BH_RED 101
 #define BH_GREEN 102
@@ -57,7 +57,7 @@ Last modified: 14/04/2019 + Rename headers
 #define BH_CYAN 106
 #define BH_WHITE 107
 
-// Foreground colors high intensity                                                                                                                                     
+// Foreground colors high intensity
 #define FH_BLACK 90
 #define FH_RED 91
 #define FH_GREEN 92
@@ -71,17 +71,17 @@ Last modified: 14/04/2019 + Rename headers
 /* FUNCTION PROTOTYPES                                                */
 /*====================================================================*/
 
-void    pushTerm();
-int     resetTerm();
-int     kbhit();
-int     readch();
-void    resetch();
+void    pushTerm(void);
+int     resetTerm(void);
+int     kbhit(void);
+int     readch(void);
+void    resetch(void);
 //char    getch(void);
 void    gotoxy(int x, int y);
 void    outputcolor(int foreground, int background);
 void    screencol(int x);
 void    resetAnsi(int x);
 int     get_terminal_dimensions(int *rows, int *columns);
-void    showcursor();
-void    hidecursor();
+void    showcursor(void);
+void    hidecursor(void);
 #endif

--- a/scbuf.c
+++ b/scbuf.c
@@ -1,20 +1,20 @@
-/* 
+/*
 ======================================================================
 SCREEN MODULE - CODE
 Description:
-Module to create a double screen buffer to control how things are 
-displayed on the terminal. Simple linked list with a "cell" that 
-stores the character to be shown along with its background and 
-foreground colors. The size of our buffer will be determined by 
-sc_rows x sc_columns. 
-Everything you want to show on screen will be printed to the 
-buffer first. Then the update routine will finally show the final 
+Module to create a double screen buffer to control how things are
+displayed on the terminal. Simple linked list with a "cell" that
+stores the character to be shown along with its background and
+foreground colors. The size of our buffer will be determined by
+sc_rows x sc_columns.
+Everything you want to show on screen will be printed to the
+buffer first. Then the update routine will finally show the final
 composition to the user.
 
 @author : Velorek
 @version : 1.0
-Last modified : 15/04/2019 ScreeChanged added + update_ch. 
-			   Update_smart corrected
+Last modified : 15/04/2019 ScreeChanged added + update_ch.
+               Update_smart corrected
 =====================================================================
 */
 
@@ -25,7 +25,7 @@ Last modified : 15/04/2019 ScreeChanged added + update_ch.
 #include <stdio.h>
 #include <string.h>
 #include <locale.h>
-#include <wchar.h>		/* wint_t */
+#include <wchar.h>      /* wint_t */
 #include "rterm.h"
 //#include "keyb.h"
 #include "scbuf.h"
@@ -86,13 +86,13 @@ Last modified : 15/04/2019 ScreeChanged added + update_ch.
 
 SCREENCELL *primary_start = NULL;
 SCREENCELL *primary_end = NULL;
-SCREENCELL *secondary_start = NULL;	//backup secondary buffer
-SCREENCELL *secondary_end = NULL;	//backup secondary buffer
+SCREENCELL *secondary_start = NULL; //backup secondary buffer
+SCREENCELL *secondary_end = NULL;   //backup secondary buffer
 SCREENCELL *screen, *old_screen;
 
 int     sc_rows, sc_columns;
 int     buffersize;
-int     bufferON = 0;		//It keeps track of whether the 2nd buffer is full (active).
+int     bufferON = 0;       //It keeps track of whether the 2nd buffer is full (active).
 
 /*====================================================================*/
 /* FUNCTIONS - CODE                                                   */
@@ -102,8 +102,8 @@ int     bufferON = 0;		//It keeps track of whether the 2nd buffer is full (activ
 /* Create screen in memory */
 /*-------------------------*/
 
-void create_screen() {
-  /* 
+void create_screen(void) {
+  /*
      Get terminal dimensions and create 2 dynamic lists with the size of the screen.
      if it is not possible to determine screen dimensions default is set to 80x25.
      Insertion happens at the end of the list. There are three pointers to keep track
@@ -133,9 +133,9 @@ void create_screen() {
     screen->index = 0;
     screen->sc_rows = sc_rows;
     screen->sc_columns = sc_columns;
-    primary_start = screen;	// Pointer to first cell
-    primary_end = screen;	// Pointer to last/previous cell
-    primary_end->next = NULL;	//Last item of the list next points to NULL
+    primary_start = screen; // Pointer to first cell
+    primary_end = screen;   // Pointer to last/previous cell
+    primary_end->next = NULL;   //Last item of the list next points to NULL
   }
   for(i = 1; i <= buffersize - 1; i++) {
     //Additional items
@@ -144,11 +144,11 @@ void create_screen() {
     new_cell->forecolor0 = F_WHITE;
     new_cell->item = FILL_CHAR;
     new_cell->index = i;
-    new_cell->sc_rows = sc_rows;	//Each cell stores screen dimensions
+    new_cell->sc_rows = sc_rows;    //Each cell stores screen dimensions
     new_cell->sc_columns = sc_columns;
     primary_end->next = new_cell;
     primary_end = new_cell;
-    primary_end->next = NULL;	//Last item of the list next points to NULL
+    primary_end->next = NULL;   //Last item of the list next points to NULL
   }
 
   // Create secondary buffer to be used as an 'undo' buffer
@@ -162,9 +162,9 @@ void create_screen() {
     old_screen->sc_rows = sc_rows;
     old_screen->sc_columns = sc_columns;
     old_screen->index = 0;
-    secondary_start = old_screen;	// Pointer to first cell
-    secondary_end = old_screen;	// Pointer to last/previous cell
-    secondary_end->next = NULL;	//Last item of the list next points to NULL
+    secondary_start = old_screen;   // Pointer to first cell
+    secondary_end = old_screen; // Pointer to last/previous cell
+    secondary_end->next = NULL; //Last item of the list next points to NULL
   }
   for(i = 1; i <= buffersize - 1; i++) {
     //Additional items
@@ -173,11 +173,11 @@ void create_screen() {
     newo_cell->forecolor0 = F_WHITE;
     newo_cell->item = FILL_CHAR;
     newo_cell->index = i;
-    newo_cell->sc_rows = sc_rows;	//Each cell stores screen dimensions
+    newo_cell->sc_rows = sc_rows;   //Each cell stores screen dimensions
     newo_cell->sc_columns = sc_columns;
     secondary_end->next = newo_cell;
     secondary_end = newo_cell;
-    secondary_end->next = NULL;	//Last item of the list next points to NULL
+    secondary_end->next = NULL; //Last item of the list next points to NULL
   }
 
 }
@@ -186,14 +186,14 @@ void create_screen() {
 /* Copy primary buffer to second buffer */
 /*--------------------------------------*/
 
-void save_buffer() {
+void save_buffer(void) {
   //Copies primary buffer into secondary buffer.
   //Thereby saving current screen to be retrieved later.
   int     i;
   SCREENCELL *aux, *aux2;
-  bufferON = SECONDARYBUFFER_ON;	// =1
-  aux = primary_start;		// Points to the first item of the first buffer
-  aux2 = secondary_start;	//Points to the first item of the second buffer 
+  bufferON = SECONDARYBUFFER_ON;    // =1
+  aux = primary_start;      // Points to the first item of the first buffer
+  aux2 = secondary_start;   //Points to the first item of the second buffer
   for(i = 0; i < buffersize; i++) {
     //Copy buffer 1 into buffer 2.
     aux2->forecolor0 = aux->forecolor0;
@@ -207,12 +207,12 @@ void save_buffer() {
 /* FLUSH primary buffer */
 /*----------------------*/
 
-void flush_buffer() {
+void flush_buffer(void) {
   //Copies primary buffer into secondary buffer.
   //Thereby saving current screen to be retrieved later.
   int     i;
   SCREENCELL *aux;
-  aux = primary_start;		// Points to the first item of the first buffer
+  aux = primary_start;      // Points to the first item of the first buffer
   for(i = 0; i < buffersize; i++) {
     //Copy buffer 1 into buffer 2.
     aux->item = FILL_CHAR;
@@ -225,14 +225,14 @@ void flush_buffer() {
 /* Copy secondary buffer into primary buffer         */
 /*---------------------------------------------------*/
 
-void restore_buffer() {
+void restore_buffer(void) {
   //Copies buffer 2 into buffer 1
   //Retrieve previous screen from memory.
   int     i;
   SCREENCELL *aux, *aux2;
-  aux = primary_start;		// Points to the first item of the first buffer
-  aux2 = secondary_start;	//Points to the first item of the second buffer 
-  bufferON = SECONDARYBUFFER_OFF;	//=0
+  aux = primary_start;      // Points to the first item of the first buffer
+  aux2 = secondary_start;   //Points to the first item of the second buffer
+  bufferON = SECONDARYBUFFER_OFF;   //=0
   for(i = 0; i < buffersize; i++) {
     //Copy buffer 2 into buffer 1.
     aux->forecolor0 = aux2->forecolor0;
@@ -288,20 +288,20 @@ int mapChartoU8(int character) {
 /* Reports whether screen has changed       */
 /*------------------------------------------*/
 
-int screenChanged() {
+int screenChanged(void) {
 
   int     i;
   int     changed=0;
   SCREENCELL *aux, *aux2;
   aux = primary_start;
-  aux2 = secondary_start; 
+  aux2 = secondary_start;
   for(i = 0; i <= buffersize; i++) {
-    if(aux->item != aux2->item || 
-	aux->forecolor0 != aux2->forecolor0 || 
-	aux->backcolor0 != aux2->backcolor0 ) {
+    if(aux->item != aux2->item ||
+    aux->forecolor0 != aux2->forecolor0 ||
+    aux->backcolor0 != aux2->backcolor0 ) {
          changed=1;
      }
-   
+
    if(aux->next != NULL)
       aux = aux->next;
    if(aux2->next != NULL)
@@ -321,15 +321,15 @@ char read_char(int x, int y) {
   char ch = FILL_CHAR;
   SCREENCELL *aux;
   if (bufferON==1)  //check whether savebuffer to use in the dynamic shadow
-    aux = secondary_start;		// we set our auxiliary pointer at the beginning of the list.
+    aux = secondary_start;      // we set our auxiliary pointer at the beginning of the list.
   else
     aux = primary_start;
-  pos = (y - 1) * sc_columns + x;	//this is the formula to calculate the position index in the screen buffer
+  pos = (y - 1) * sc_columns + x;   //this is the formula to calculate the position index in the screen buffer
  if(pos <= buffersize) {
   for(i = 0; i <= pos; i++) {
       //run through the buffer until reaching desired position
       if(aux->index == pos)
-	break;
+    break;
       aux = aux->next;
     }
   ch = aux->item;
@@ -347,15 +347,15 @@ void flush_cell(int x, int y) {
   int     i, pos;
   SCREENCELL *aux;
   if (bufferON==1)  //check whether savebuffer to use in the dynamic shadow
-    aux = secondary_start;		// we set our auxiliary pointer at the beginning of the list.
+    aux = secondary_start;      // we set our auxiliary pointer at the beginning of the list.
   else
     aux = primary_start;
-  pos = (y - 1) * sc_columns + x;	//this is the formula to calculate the position index in the screen buffer
+  pos = (y - 1) * sc_columns + x;   //this is the formula to calculate the position index in the screen buffer
  if(pos <= buffersize) {
   for(i = 0; i <= pos; i++) {
       //run through the buffer until reaching desired position
       if(aux->index == pos)
-	break;
+    break;
       aux = aux->next;
     }
   aux->item = FILL_CHAR;
@@ -371,15 +371,15 @@ void write_ch(int x, int y, char ch, int backcolor, int forecolor) {
 /* It will be shown on screen when it is updated by calling update_screen */
   int     i, pos;
   SCREENCELL *aux;
-  aux = primary_start;		// we set our auxiliary pointer at the beginning of the list.
-  pos = (y - 1) * sc_columns + x;	//This is the formula to calculate the position index in the screen buffer
+  aux = primary_start;      // we set our auxiliary pointer at the beginning of the list.
+  pos = (y - 1) * sc_columns + x;   //This is the formula to calculate the position index in the screen buffer
 
   if(pos <= buffersize) {
-    // If it is within buffer limits, otherwise do nothing.  
+    // If it is within buffer limits, otherwise do nothing.
     for(i = 0; i <= pos; i++) {
       //Run through the buffer until reaching desired position
       if(aux->index == pos)
-	break;
+    break;
       aux = aux->next;
     }
     //Update cell info at position selected.
@@ -408,7 +408,7 @@ void write_str(int x, int y, char *str, int backcolor, int forecolor) {
   for(i = 0; i <= strlen(str) - 1; i++) {
     write_ch(wherex, y, astr[i], backcolor, forecolor);
     wherex = wherex + 1;
-  
+
   }
   //astr = NULL;
   //free(astr);
@@ -419,7 +419,7 @@ void write_str(int x, int y, char *str, int backcolor, int forecolor) {
 /*-----------------------------------------------*/
 
 int write_num(int x, int y, int num, int length, int backcolor,
-	       int forecolor) {
+           int forecolor) {
   //the length of the string must be passed on the function
   char   *astr;
   char len;
@@ -437,35 +437,35 @@ int write_num(int x, int y, int num, int length, int backcolor,
 void update_ch(int x, int y, char ch, char specialChar, int backcolor, int forecolor) {
 //It could be interepreted as write_ch - forced update to screen
 //to be used to simplify code in update_smart.
-signed char tempchar=0;     
+signed char tempchar=0;
    gotoxy(x, y);
    outputcolor(forecolor, backcolor);
    if(ch > 0)
       // Check whether chars are negative
       printf("%c", ch);
    else {
-      /* 
-         For convention, if we have negative chars that means that we 
+      /*
+         For convention, if we have negative chars that means that we
          are printing box-like characters or accents to screen.
          Box characters are mapped to Unicode. */
   //printf("%c(0",27); //Deprecated - Activate box-like characters in vt-100
   // printf("%c(B",27); //Deactivate box-like characters
     if(ch >= -55 && ch <= -50) {
-	//Box chars.
-	setlocale(LC_ALL, "");
-	tempchar = ch * -1;	//Change negative values to positive.
-	printf("%lc", (wint_t) mapChartoU8(tempchar));	//unicode
+    //Box chars.
+    setlocale(LC_ALL, "");
+    tempchar = ch * -1; //Change negative values to positive.
+    printf("%lc", (wint_t) mapChartoU8(tempchar));  //unicode
     }
     if(ch <= -65)
-	//Accents -61/-62 + char
-	printf("%c%c", specialChar, ch);
+    //Accents -61/-62 + char
+    printf("%c%c", specialChar, ch);
     }
 }
 /*------------------------------------*/
 /* Dumps buffer to screen for display */
 /*------------------------------------*/
 
-void update_screen() {
+void update_screen(void) {
   int     i, wherex, wherey;
   SCREENCELL *aux;
   wherey = 1;
@@ -478,7 +478,7 @@ void update_screen() {
 
    if(aux->next != NULL)
       aux = aux->next;
-   wherex = wherex + 1;	//line counter
+   wherex = wherex + 1; //line counter
     if(wherex == sc_columns+1) {
       //new line
       wherex = 1;
@@ -487,7 +487,7 @@ void update_screen() {
  }
 }
 
-int update_smart() {
+int update_smart(void) {
 //Note: if wherex = 0 then wherex=sc_columns i
 // and wherey--; because of the result of modulus operation
   int     i, wherex, wherey;
@@ -532,7 +532,7 @@ return changed;
 /* Restore previous buffer */
 /*-------------------------*/
 
-void close_window() {
+void close_window(void) {
   restore_buffer();
   update_screen();
 }
@@ -557,56 +557,56 @@ void screen_color(int color) {
 /* Destroy both screen buffers */
 /*-----------------------------*/
 /* Function to delete the entire linked list */
-void free_buffer() 
-{ 
+void free_buffer(void)
+{
    /* deref head_ref to get the real head */
-   SCREENCELL *current; 
-   SCREENCELL *next; 
+   SCREENCELL *current;
+   SCREENCELL *next;
    current=primary_start;
-  
-   while (current != NULL)  
-   { 
-       next = current->next; 
+
+   while (current != NULL)
+   {
+       next = current->next;
        //if (current != NULL){
          free(current);
        //}
-       current = next; 
-   } 
+       current = next;
+   }
     current=secondary_start;
-  
-   while (current != NULL)  
-   { 
-       next = current->next; 
+
+   while (current != NULL)
+   {
+       next = current->next;
        //if (current != NULL){
          free(current);
        //}
-       current = next; 
-   } 
-   free(current); 
-   /* deref head_ref to affect the real head back 
+       current = next;
+   }
+   free(current);
+   /* deref head_ref to affect the real head back
       in the caller. */
    primary_start = NULL;
   primary_end = NULL;
   secondary_start = NULL;
   secondary_end = NULL;
-} 
+}
 
 /*------------------------------------------*/
 /* Draw window area with or without border. */
 /*------------------------------------------*/
 
 void draw_window(int x1, int y1, int x2, int y2, int backcolor,
-		 int bordercolor, int titlecolor, int border, int title) {
-/* 
+         int bordercolor, int titlecolor, int border, int title) {
+/*
    Chars for drawing box-like characters will be passed as negative values.
    When the update_screen routine is called, it will check for negative
-   values and map these chars to Unicode characters. 
+   values and map these chars to Unicode characters.
  */
   int     i, j;
   char ch=FILL_CHAR;
   i = x1;
   j = y1;
-  save_buffer();		//saves screen to be restored later in close_window
+  save_buffer();        //saves screen to be restored later in close_window
   //shadow
   for(j = y1 + 1; j <= y2 + 1; j++)
     for(i = x1 + 1; i <= x2 + 1; i++)
@@ -624,18 +624,18 @@ void draw_window(int x1, int y1, int x2, int y2, int backcolor,
     //with borders. ANSI-ASCII 106-121
     for(i = x1; i <= x2; i++) {
       //upper and lower borders
-      write_ch(i, y1, NHOR_LINE, backcolor, bordercolor);	//horizontal line box-like char
+      write_ch(i, y1, NHOR_LINE, backcolor, bordercolor);   //horizontal line box-like char
       write_ch(i, y2, NHOR_LINE, backcolor, bordercolor);
     }
     for(j = y1; j <= y2; j++) {
       //left and right borders
-      write_ch(x1, j, NVER_LINE, backcolor, bordercolor);	//vertical line box-like char
+      write_ch(x1, j, NVER_LINE, backcolor, bordercolor);   //vertical line box-like char
       write_ch(x2, j, NVER_LINE, backcolor, bordercolor);
     }
-    write_ch(x1, y1, NUPPER_LEFT_CORNER, backcolor, bordercolor);	//upper-left corner box-like char
-    write_ch(x1, y2, NLOWER_LEFT_CORNER, backcolor, bordercolor);	//lower-left corner box-like char
-    write_ch(x2, y1, NUPPER_RIGHT_CORNER, backcolor, bordercolor);	//upper-right corner box-like char
-    write_ch(x2, y2, NLOWER_RIGHT_CORNER, backcolor, bordercolor);	//lower-right corner box-like char
+    write_ch(x1, y1, NUPPER_LEFT_CORNER, backcolor, bordercolor);   //upper-left corner box-like char
+    write_ch(x1, y2, NLOWER_LEFT_CORNER, backcolor, bordercolor);   //lower-left corner box-like char
+    write_ch(x2, y1, NUPPER_RIGHT_CORNER, backcolor, bordercolor);  //upper-right corner box-like char
+    write_ch(x2, y2, NLOWER_RIGHT_CORNER, backcolor, bordercolor);  //lower-right corner box-like char
   }
   if (title == 1) {
     for(i = x1; i <= x2; i++)

--- a/scbuf.h
+++ b/scbuf.h
@@ -1,6 +1,6 @@
-/* 
+/*
 ======================================================================
-HEADER: Module to create a double screen buffer to control how things 
+HEADER: Module to create a double screen buffer to control how things
 are displayed on the terminal.
 
 @author : Velorek
@@ -19,7 +19,7 @@ Last modified : 14/4/2019 Rename headers + screenChanged added
 #include <stdio.h>
 #include <string.h>
 #include <locale.h>
-#include <wchar.h>		/* wint_t */
+#include <wchar.h>      /* wint_t */
 #include "rterm.h"
 #include "keyb.h"
 
@@ -42,39 +42,39 @@ Last modified : 14/4/2019 Rename headers + screenChanged added
 /*====================================================================*/
 
 typedef struct _screencell {
-  int     index;		// Item number
-  int     backcolor0;		// Back and Fore colors of each cell
+  int     index;        // Item number
+  int     backcolor0;       // Back and Fore colors of each cell
   int     forecolor0;
-  int     sc_rows;			//Save screen dimensions
+  int     sc_rows;          //Save screen dimensions
   int     sc_columns;
-  char    item;			// Item string
-  int     specialchar;		// Control for accents and special chars   
-  struct _screencell *next;	// Pointer to next item
+  char    item;         // Item string
+  int     specialchar;      // Control for accents and special chars
+  struct _screencell *next; // Pointer to next item
 } SCREENCELL;
 
 /*====================================================================*/
 /* FUNCTION PROTOTYPES                                                */
 /*====================================================================*/
 
-void    create_screen();
+void    create_screen(void);
 void    write_ch(int x, int y, char ch, int backcolor, int forecolor);
 char    read_char(int x, int y);
 void    write_str(int x, int y, char *str, int backcolor, int forecolor);
 int     write_num(int x, int y, int num, int length, int backcolor,
-		  int forecolor);
-void    save_buffer();
-void    restore_buffer();
+          int forecolor);
+void    save_buffer(void);
+void    restore_buffer(void);
 void    screen_color(int color);
-void    free_buffer();
+void    free_buffer(void);
 void    draw_window(int x1, int y1, int x2, int y2, int backcolor,
-		    int bordercolor, int titlecolor, int border, int title);
-void    close_window();
+int     bordercolor, int titlecolor, int border, int title);
+void    close_window(void);
 int     mapChartoU8(int character);
-void    update_screen();
+void    update_screen(void);
 void    update_ch(int x, int y, char ch, char specialChar, int backcolor, int forecolor);
-int 	screenChanged();
-int     update_smart();
-void    flush_buffer();
+int     screenChanged(void);
+int     update_smart(void);
+void    flush_buffer(void);
 void    flush_cell(int x, int y);
 void    clearString(char *string, int max);
 

--- a/tm.c
+++ b/tm.c
@@ -28,7 +28,7 @@ long res, res2;
     }
     //Calculate tick by divided time elapsed with ms requested
     res2 = mytimer1->elapsed / mytimer1->ms;
-    if (res2 == mytimer1->oldticks) {  
+    if (res2 == mytimer1->oldticks) {
       mytimer1->ticks = mytimer1->ticks + 1;
       mytimer1->oldticks = mytimer1->oldticks+1;
       return 1;

--- a/tm.h
+++ b/tm.h
@@ -1,10 +1,10 @@
 /*
 ========================================================================
-- HEADER - 
+- HEADER -
 Module to implement a millisecond TIMER in C.
 @author : Velorek
-@version : 1.0  
-Last modified: 27/12/2020 + New module                                                                
+@version : 1.0
+Last modified: 27/12/2020 + New module
 ========================================================================
 */
 
@@ -24,10 +24,10 @@ Last modified: 27/12/2020 + New module
 /*====================================================================*/
 typedef struct nTimer{
         int  ms; //milliseconds
-	long oldtime; //to calculate increment in time
-	long oldticks; //to calculate increment in no. of ticks
-	long ticks; //how many ticks have been made
-	long elapsed; //total time elapsed in ms
+    long oldtime; //to calculate increment in time
+    long oldticks; //to calculate increment in no. of ticks
+    long ticks; //how many ticks have been made
+    long elapsed; //total time elapsed in ms
 } NTIMER;
 
 /* Miliseconds timer */

--- a/uintf.c
+++ b/uintf.c
@@ -1,11 +1,11 @@
-/* 
+/*
 ======================================================================
 Module to manage user interface options like menus,
 windows, textbox, etc.
 
 @author : Velorek
 @version : 1.0
- 
+
 LAST MODIFIED : 30/12/2020 - Adapted for FileViewer
 ======================================================================
 */
@@ -26,7 +26,7 @@ LAST MODIFIED : 30/12/2020 - Adapted for FileViewer
 
 #define K_ENTER 13
 #define K_TAB 9
-#define MAX_TEXT 150		//MENU CONSTANTS
+#define MAX_TEXT 150        //MENU CONSTANTS
 #define HOR_MENU -1
 #define FILE_MENU 0
 #define HELP_MENU 1
@@ -41,7 +41,7 @@ LAST MODIFIED : 30/12/2020 - Adapted for FileViewer
 #define OPTION_3 2
 #define OPTION_4 3
 #define OPTION_5 4
-#define OPTION_NIL -1		//Reset option
+#define OPTION_NIL -1       //Reset option
 #define CONFIRMATION 1
 #define CANCEL 2
 
@@ -69,7 +69,7 @@ int SCROLLBAR_BACK= B_WHITE;
 int SCROLLBAR_FORE= F_WHITE;
 int SCROLLBAR_SEL= B_CYAN;
 int SCROLLBAR_ARR= B_BLACK;
-int WINDOW_TITLEB = B_BLACK; 
+int WINDOW_TITLEB = B_BLACK;
 int WINDOW_TITLEF = F_WHITE;
 
 /*====================================================================*/
@@ -119,8 +119,8 @@ void loadmenus(LISTCHOICE * mylist, int choice) {
 /*----------------------------*/
 
 int textbox(int wherex, int wherey, int displayLength,
-	    char label[MAX_TEXT], char text[MAX_TEXT], int backcolor,
-	    int labelcolor, int textcolor) {
+        char label[MAX_TEXT], char text[MAX_TEXT], int backcolor,
+        int labelcolor, int textcolor) {
   int     charCount = 0;
   int     exitFlag = 0;
   int     cursorON = 1;
@@ -142,7 +142,7 @@ int textbox(int wherex, int wherey, int displayLength,
     write_ch(i, wherey, '.', backcolor, textcolor);
   }
   write_ch(positionx + displayLength + 1, wherey, ']', backcolor,
-	   textcolor);
+       textcolor);
   update_screen();
   //Reset keyboard
   if(kbhit() == 1) ch = readch();
@@ -156,8 +156,8 @@ int textbox(int wherex, int wherey, int displayLength,
     if(cursorCount == 10000) {
       cursorCount = 0;
       switch (cursorON) {
-	case 1:
-	  posCursor = positionx + 1;
+    case 1:
+      posCursor = positionx + 1;
           displayChar = '.';
           if (posCursor == limitCursor) {
             posCursor = posCursor - 1;
@@ -166,38 +166,38 @@ int textbox(int wherex, int wherey, int displayLength,
           write_ch(posCursor, wherey, displayChar, backcolor, textcolor);
           update_screen();
           cursorON = 0;
-	  break;
-	case 0:
+      break;
+    case 0:
           posCursor = positionx + 1;
           if (posCursor == limitCursor) posCursor = posCursor - 1;
-	  write_ch(posCursor, wherey, '|', backcolor, textcolor);
+      write_ch(posCursor, wherey, '|', backcolor, textcolor);
           update_screen();
           cursorON = 1;
-	  break;
+      break;
       }
-     } 
+     }
     }
-    //Process keys     
+    //Process keys
     if(keypressed == 1) {
       ch = readch();
       keypressed = 0;
-      
+
       //Read special keys
       if (ch==K_ESCAPE) {
-               read_keytrail(chartrail);    
+               read_keytrail(chartrail);
       }
       //Read accents
       //if (ch==SPECIAL_CHARSET_1) read_accentchar(&ch, accentchar);
       //if (ch==SPECIAL_CHARSET_2) read_accentchar(&ch, accentchar);
 
       if(charCount < displayLength) {
-	if(ch > 31 && ch < 127) {
-	  write_ch(positionx + 1, wherey, ch, backcolor, textcolor);
-	  text[charCount] = ch;
-	  positionx++;
-	  charCount++;
-	  update_screen();
-	}
+    if(ch > 31 && ch < 127) {
+      write_ch(positionx + 1, wherey, ch, backcolor, textcolor);
+      text[charCount] = ch;
+      positionx++;
+      charCount++;
+      update_screen();
+    }
       }
     }
     if (ch==K_BACKSPACE){
@@ -240,21 +240,21 @@ int infoWindow(LISTCHOICE * mylist, char *message, char *windowTitle) {
   loadmenus(mylist, OK_MENU);
 
   draw_window(window_x1, window_y1, window_x2, window_y2, MENU_PANEL, MENU_FOREGROUND0,
-	      WINDOW_TITLEB,1,1);
+          WINDOW_TITLEB,1,1);
   write_str((window_x2-window_x1) /2 + window_x1 - (strlen(windowTitle)/2) , window_y1-1, windowTitle, WINDOW_TITLEB, WINDOW_TITLEF);
-  //Write message to info window  
+  //Write message to info window
   for(i = 0; i < strlen(message); i++) {
     tempChar = message[i];
     //Maximum four lines
     if(j < 4) {
       //Split message if \n
       if(tempChar == '\n') {
-	j++;
-	ix = 0;
+    j++;
+    ix = 0;
       } else {
-	write_ch(window_x1 + 1 + ix, window_y1 + 1 + j, tempChar, MENU_FOREGROUND0,
-		 MENU_PANEL);
-	ix++;
+    write_ch(window_x1 + 1 + ix, window_y1 + 1 + j, tempChar, MENU_FOREGROUND0,
+         MENU_PANEL);
+    ix++;
       }
     }
   }
@@ -262,7 +262,7 @@ int infoWindow(LISTCHOICE * mylist, char *message, char *windowTitle) {
   free_list(mylist);
   close_window();
   if(data.index == OPTION_1)
-    ok = CONFIRMATION;		//Confirmation has been given 
+    ok = CONFIRMATION;      //Confirmation has been given
   return ok;
 }
 
@@ -285,21 +285,21 @@ int alertWindow(LISTCHOICE * mylist, char *message, char *windowTitle) {
   loadmenus(mylist, OK_MENU2);
 
   draw_window(window_x1, window_y1, window_x2, window_y2, MENU_PANEL, MENU_FOREGROUND0,
-	      WINDOW_TITLEB,1,1);
+          WINDOW_TITLEB,1,1);
   write_str((window_x2-window_x1) /2 + window_x1 - (strlen(windowTitle)/2) , window_y1-1, windowTitle, WINDOW_TITLEB, WINDOW_TITLEF);
-  //Write message to alert window  
+  //Write message to alert window
   for(i = 0; i < strlen(message); i++) {
     tempChar = message[i];
     //Maximum four lines
     if(j < 5) {
       //Split message if \n
       if(tempChar == '\n') {
-	j++;
-	ix = 0;
+    j++;
+    ix = 0;
       } else {
-	write_ch(window_x1 + 1 + ix, window_y1 + 1 + j, tempChar, MENU_FOREGROUND0,
-		 MENU_PANEL);
-	ix++;
+    write_ch(window_x1 + 1 + ix, window_y1 + 1 + j, tempChar, MENU_FOREGROUND0,
+         MENU_PANEL);
+    ix++;
       }
     }
   }
@@ -307,7 +307,7 @@ int alertWindow(LISTCHOICE * mylist, char *message, char *windowTitle) {
   free_list(mylist);
   close_window();
   if(data.index == OPTION_1)
-    ok = CONFIRMATION;		//Confirmation has been given 
+    ok = CONFIRMATION;      //Confirmation has been given
   return ok;
 }
 
@@ -330,28 +330,28 @@ int yesnoWindow(LISTCHOICE * mylist, char *message, char *windowTitle) {
   window_x2 = (columns / 2) + 13;
   loadmenus(mylist, YESNO_MENU);
   draw_window(window_x1, window_y1, window_x2, window_y2, MENU_PANEL, MENU_FOREGROUND0,
-	      WINDOW_TITLEB,1,1);
+          WINDOW_TITLEB,1,1);
   write_str((window_x2-window_x1) /2 + window_x1 - (strlen(windowTitle)/2) , window_y1-1, windowTitle, WINDOW_TITLEB, WINDOW_TITLEF);
-  //Write message to yes/no window  
+  //Write message to yes/no window
   for(i = 0; i < strlen(message); i++) {
     tempChar = message[i];
     //Maximum four lines
     if(j < 4) {
       //Split message if \n
       if(tempChar == '\n') {
-	j++;
-	ix = 0;
+    j++;
+    ix = 0;
       } else {
-	write_ch(window_x1 + 1 + ix, window_y1 + 1 + j, tempChar, MENU_FOREGROUND0,
-		 MENU_PANEL);
-	ix++;
+    write_ch(window_x1 + 1 + ix, window_y1 + 1 + j, tempChar, MENU_FOREGROUND0,
+         MENU_PANEL);
+    ix++;
       }
     }
   }
   start_hmenu(&data);
   free_list(mylist);
   if(data.index == OPTION_1)
-    ok = CONFIRMATION;		//Confirmation has been given
+    ok = CONFIRMATION;      //Confirmation has been given
   if(data.index == OPTION_3)
     ok = CANCEL;
   close_window();
@@ -371,11 +371,11 @@ int inputWindow(char *label, char *tempFile, char *windowTitle) {
   window_x2 = (columns / 2) + 14;
 
   draw_window(window_x1, window_y1, window_x2, window_y2, MENU_PANEL, MENU_FOREGROUND0,
-	      WINDOW_TITLEB,1,1);
+          WINDOW_TITLEB,1,1);
   write_str((window_x2-window_x1) /2 + window_x1 - (strlen(windowTitle)/2) , window_y1-1, windowTitle, WINDOW_TITLEB, WINDOW_TITLEF);
   count =
       textbox(window_x1 + 1, window_y1 + 1, 16, label, tempFile, MENU_PANEL,
-	      MENU_FOREGROUND0, MENU_FOREGROUND0);
+          MENU_FOREGROUND0, MENU_FOREGROUND0);
   close_window();
   return count;
 }
@@ -400,19 +400,19 @@ int helpWindow(LISTCHOICE * mylist, char *message, char *windowTitle) {
   draw_window(window_x1, window_y1, window_x2, window_y2, MENU_PANEL, MENU_FOREGROUND0,WINDOW_TITLEB,1,1);
   write_str((window_x2-window_x1) /2 + window_x1 - (strlen(windowTitle)/2) , window_y1-1, windowTitle, WINDOW_TITLEB, WINDOW_TITLEF);
 
-  //Write message to info window  
+  //Write message to info window
   for(i = 0; i < strlen(message); i++) {
     tempChar = message[i];
     //Maximum four lines
     if(j < window_y2-2) {
       //Split message if \n
       if(tempChar == '\n') {
-	j++;
-	ix = 0;
+    j++;
+    ix = 0;
       } else {
-	write_ch(window_x1 + 2 + ix, window_y1 + 1 + j, tempChar, MENU_FOREGROUND0,
-		 MENU_PANEL);
-	ix++;
+    write_ch(window_x1 + 2 + ix, window_y1 + 1 + j, tempChar, MENU_FOREGROUND0,
+         MENU_PANEL);
+    ix++;
       }
     }
   }
@@ -421,7 +421,7 @@ int helpWindow(LISTCHOICE * mylist, char *message, char *windowTitle) {
   free_list(mylist);
   close_window();
   if(data.index == OPTION_1)
-    ok = CONFIRMATION;		//Confirmation has been given 
+    ok = CONFIRMATION;      //Confirmation has been given
   return ok;
 }
 

--- a/uintf.h
+++ b/uintf.h
@@ -1,11 +1,11 @@
 /*
 ========================================================================
-- HEADER - 
+- HEADER -
 Module to show user interface windows, textbox, etc.
 @author : Velorek
-@version : 1.0  
+@version : 1.0
 Last modified: 30/12/2020 Adapted for FileViewer
-                                                                
+
 ========================================================================
 */
 
@@ -52,14 +52,14 @@ Last modified: 30/12/2020 Adapted for FileViewer
 #define OPTION_3 2
 #define OPTION_4 3
 #define OPTION_5 4
-#define OPTION_NIL -1		//Reset option
+#define OPTION_NIL -1       //Reset option
 #define CONFIRMATION 1
-#define K_LEFTMENU -1		//Left arrow key pressed while in menu
-#define K_RIGHTMENU -2		//Right arrow key pressed while in menu
+#define K_LEFTMENU -1       //Left arrow key pressed while in menu
+#define K_RIGHTMENU -2      //Right arrow key pressed while in menu
 
 //EDIT CONSTANTS
 #define CHAR_NIL '\0'
-#define END_LINE_CHAR 0x0A	// $0A
+#define END_LINE_CHAR 0x0A  // $0A
 #define FILL_CHAR 32
 
 //GLOBAL VARIABLES - COLOR SCHEME
@@ -93,8 +93,8 @@ extern int WINDOW_TITLEF;
 void    loadmenus(LISTCHOICE * mylist, int choice);
 
 int     textbox(int wherex, int wherey, int displayLength,
-		char label[MAX_TEXT], char text[MAX_TEXT], int backcolor,
-		int labelcolor, int textcolor);
+        char label[MAX_TEXT], char text[MAX_TEXT], int backcolor,
+        int labelcolor, int textcolor);
 int     alertWindow(LISTCHOICE * mylist, char *message, char *windowTitle);
 int     infoWindow(LISTCHOICE * mylist, char *message, char *windowTitle);
 int     inputWindow(char *label, char *tempFile, char *windowTitle);


### PR DESCRIPTION
format code: use 4 spaces to replace tab
give void functions an arg type to avoid complier's warning